### PR TITLE
NEOAPP-730: Data export - Zim-Pari and CPH

### DIFF
--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -156,7 +156,8 @@ def deduplicate_maternal_query(mat_outcomes_where):
                     -- We could replace with max(id) to take the 
                     -- most recently uploaded
             from public.sessions
-            where scriptid {mat_outcomes_where} -- only pull out maternal  data
+            where scriptid {mat_outcomes_where}  -- only pull out maternal  data
+            and ingested_at > '2022-08-01' 
             group by 1,2
             )
             select


### PR DESCRIPTION
Limited dataset for maternal outcome deduplication query to 2022-08-01 to date. Will need to investigate further if we can configure at database level to allow large dataset query