### PR TITLE
Add safe UID cleanup commands and optional scheduled known-test-UID purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ The `hospitals.ini` file contains hospitals script ids configurations
 8. files_dir:  Works hand in hand with the `mode` field. It is the path to the directory containing scripts that                     need to be imported into the database. The path should be specified using the path pattern of the                     operating system being in use. By Default it is `OPTIONAL` however it becomes `REQUIRED` the moment we                set `mode` to `import`
 
 9. cron_interval: An `OPTIONAL` number value used to determine the number of hours to be used before the next running                   of the automated data pipeline. If not specified, the automation script will default to `6 hours`
-10. known_test_uid_cleanup_interval: An `OPTIONAL` number value used to determine the number of hours between runs of the scheduled known test UID cleanup job. If omitted or set to `0`, the cleanup job will not be installed.
-11. known_test_uid_cleanup_max_rows: An `OPTIONAL` number value used as a safety cutoff for the scheduled known test UID cleanup job. If the dry run for a known test UID exceeds this number, deletion is skipped. The default is `100`
+10. known_test_uid_cleanup_max_rows: An `OPTIONAL` number value used as a safety cutoff for the automatic source-table preflight cleanup. Before each scheduled pipeline run, the automation script runs a known test UID cleanup against `public.sessions` and `public.clean_sessions`. If a dry run for a known test UID exceeds this number, deletion is skipped. The default is `100`
 
 ## EXAMPLE OF FULL `database.ini` FILE:
     [postgresql_dev]
@@ -154,7 +153,7 @@ After running the above command, logs should start appearing on your screen, det
 4. To confirm that your entries have been written to the crontab file, run `crontab -e` then check if your entries are available
 >It is important to specify the time zone in the `crontab` file before starting to run the automation script so that you won't have challenges with differences in server time against the time zone that you want the automation script to run.
 >To set the time zone append the following line at the top of your `crontab` file: `TZ="SPECIFY_TIMEZONE` e.g `TZ= "Africa/Harare"`
->If `known_test_uid_cleanup_interval` is configured in `database.ini`, the automation script will also install a second cron job that runs `kedro purge-known-test-uids --env=...` using the configured row-count safeguard.
+>Before each scheduled pipeline run, the automation script runs a source-only preflight cleanup using `kedro purge-known-test-uids-source-only --env=...` so known test UIDs are removed from the sessions tables before the pipeline spreads them into downstream schemas and tables.
 
 ## ALTERNATIVELY ##
 > If you have knowledge with the linux operating system, you can write the automation command directly to the cron service by following the the steps below:
@@ -204,38 +203,40 @@ Notes:
 4. Deletion is transactional, meaning the matching deletes are committed together or rolled back together if there is an error.
 5. The cleanup checks both standard UID columns and raw JSON-backed session data where NeoTree IDs may be stored.
 
-### SCHEDULED KNOWN TEST UID CLEANUP
-Use this when you want a low-cost periodic cleanup for fixed known test UIDs.
+### AUTOMATIC SOURCE-TABLE PREFLIGHT CLEANUP
+Use this when you want a low-cost automatic cleanup for fixed known test UIDs before the pipeline runs.
 
-The scheduled cleanup command is:
-`kedro purge-known-test-uids --env=prod`
+The source-only preflight command is:
+`kedro purge-known-test-uids-source-only --env=prod`
 
 This command:
 1. Uses a fixed allowlist of known test UIDs defined in the codebase.
-2. Runs a dry run internally before deleting anything.
-3. Skips deletion if the number of matches for a known test UID exceeds the configured safety threshold.
-4. Only deletes allowlisted test UIDs; it does not accept arbitrary UIDs.
+2. Only checks the source session tables: `public.sessions` and `public.clean_sessions`.
+3. Runs a dry run internally before deleting anything.
+4. Skips deletion if the number of matches for a known test UID exceeds the configured safety threshold.
+5. Only deletes allowlisted test UIDs; it does not accept arbitrary UIDs.
 
-### ENABLING SCHEDULED CLEANUP IN AUTOMATION
-To install the scheduled cleanup cron job, add the following optional values to `conf/local/database.ini`:
+### AUTOMATIC PREFLIGHT IN AUTOMATION
+To enable the source-table preflight before each scheduled pipeline run, add the following optional values to `conf/local/database.ini`:
 
 ```ini
 [postgresql_prod]
 cron_interval = 6
-known_test_uid_cleanup_interval = 12
 known_test_uid_cleanup_max_rows = 100
 ```
 
 Then run:
 `python automation.py kedro --env=prod`
 
-If `known_test_uid_cleanup_interval` is greater than `0`, the automation script will install a second cron job for:
-`kedro purge-known-test-uids --env=prod --max-rows-per-uid 100`
+The scheduled pipeline cron entry will run the source-only preflight first, then run the pipeline:
+`kedro purge-known-test-uids-source-only --env=prod --max-rows-per-uid 100`
+followed by
+`kedro run --env=prod`
 
 Recommended usage:
 1. Use manual cleanup for one-off production support actions.
-2. Use scheduled cleanup only for approved known test UIDs such as `AAAA-111111`.
-3. Start with a conservative interval such as every `12` hours.
+2. Use automatic preflight only for approved known test UIDs such as `AAAA-111111`.
+3. Let the automatic preflight clean the sessions tables before each scheduled pipeline run.
 4. Keep the safety threshold low enough to catch unexpected broad matches.
 
 ## LOGS

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The `hospitals.ini` file contains hospitals script ids configurations
 8. files_dir:  Works hand in hand with the `mode` field. It is the path to the directory containing scripts that                     need to be imported into the database. The path should be specified using the path pattern of the                     operating system being in use. By Default it is `OPTIONAL` however it becomes `REQUIRED` the moment we                set `mode` to `import`
 
 9. cron_interval: An `OPTIONAL` number value used to determine the number of hours to be used before the next running                   of the automated data pipeline. If not specified, the automation script will default to `6 hours`
+10. known_test_uid_cleanup_interval: An `OPTIONAL` number value used to determine the number of hours between runs of the scheduled known test UID cleanup job. If omitted or set to `0`, the cleanup job will not be installed.
+11. known_test_uid_cleanup_max_rows: An `OPTIONAL` number value used as a safety cutoff for the scheduled known test UID cleanup job. If the dry run for a known test UID exceeds this number, deletion is skipped. The default is `100`
 
 ## EXAMPLE OF FULL `database.ini` FILE:
     [postgresql_dev]
@@ -152,6 +154,7 @@ After running the above command, logs should start appearing on your screen, det
 4. To confirm that your entries have been written to the crontab file, run `crontab -e` then check if your entries are available
 >It is important to specify the time zone in the `crontab` file before starting to run the automation script so that you won't have challenges with differences in server time against the time zone that you want the automation script to run.
 >To set the time zone append the following line at the top of your `crontab` file: `TZ="SPECIFY_TIMEZONE` e.g `TZ= "Africa/Harare"`
+>If `known_test_uid_cleanup_interval` is configured in `database.ini`, the automation script will also install a second cron job that runs `kedro purge-known-test-uids --env=...` using the configured row-count safeguard.
 
 ## ALTERNATIVELY ##
 > If you have knowledge with the linux operating system, you can write the automation command directly to the cron service by following the the steps below:
@@ -182,6 +185,58 @@ After running the above command, logs should start appearing on your screen, det
 > You can also add the `--parallel` flag to the automation script to enable concurrency
 *NOTE*: *Your python environment should be named `env` else change the command `env/bin/python` to suit the name of your environment*
 *NOTE*: *The automation scripts should be set or run after all the setup process including the installation of dependencies has been completed*
+
+## DATA CLEANUP COMMANDS
+> The project includes commands for safely removing known test UIDs from the database.
+
+### MANUAL UID CLEANUP
+Use this when you want to inspect or remove a single specific UID manually.
+
+1. Run a dry run first:
+`kedro purge-uid --env=prod --uid AAAA-111111`
+2. If the reported matches are correct, run the delete:
+`kedro purge-uid --env=prod --uid AAAA-111111 --execute --confirm-uid AAAA-111111`
+
+Notes:
+1. The first command only scans and reports matches.
+2. The second command deletes matching rows.
+3. `--confirm-uid` must exactly match the value passed to `--uid`.
+4. Deletion is transactional, meaning the matching deletes are committed together or rolled back together if there is an error.
+5. The cleanup checks both standard UID columns and raw JSON-backed session data where NeoTree IDs may be stored.
+
+### SCHEDULED KNOWN TEST UID CLEANUP
+Use this when you want a low-cost periodic cleanup for fixed known test UIDs.
+
+The scheduled cleanup command is:
+`kedro purge-known-test-uids --env=prod`
+
+This command:
+1. Uses a fixed allowlist of known test UIDs defined in the codebase.
+2. Runs a dry run internally before deleting anything.
+3. Skips deletion if the number of matches for a known test UID exceeds the configured safety threshold.
+4. Only deletes allowlisted test UIDs; it does not accept arbitrary UIDs.
+
+### ENABLING SCHEDULED CLEANUP IN AUTOMATION
+To install the scheduled cleanup cron job, add the following optional values to `conf/local/database.ini`:
+
+```ini
+[postgresql_prod]
+cron_interval = 6
+known_test_uid_cleanup_interval = 12
+known_test_uid_cleanup_max_rows = 100
+```
+
+Then run:
+`python automation.py kedro --env=prod`
+
+If `known_test_uid_cleanup_interval` is greater than `0`, the automation script will install a second cron job for:
+`kedro purge-known-test-uids --env=prod --max-rows-per-uid 100`
+
+Recommended usage:
+1. Use manual cleanup for one-off production support actions.
+2. Use scheduled cleanup only for approved known test UIDs such as `AAAA-111111`.
+3. Start with a conservative interval such as every `12` hours.
+4. Keep the safety threshold low enough to catch unexpected broad matches.
 
 ## LOGS
 There are 3 (three) main log files that are generated by the data pipeline when it runs:

--- a/automation.py
+++ b/automation.py
@@ -2,35 +2,69 @@ from conf.common.config import config
 from conf.common.format_error import formatError
 from crontab import CronTab
 import logging
-import sys
 import os
+import sys
+
+
+DEFAULT_PIPELINE_INTERVAL_HOURS = 6
+
+
+def _build_kedro_command(project_dir, env, subcommand, extra_args=""):
+    command = f"cd {project_dir} && env/bin/python -m kedro {subcommand} --env={env}"
+    if extra_args:
+        command = f"{command} {extra_args}"
+    return command
+
+
+def _replace_job(cron, comment, command, interval_hours):
+    cron.remove_all(comment=comment)
+    job = cron.new(command=command, comment=comment)
+    job.every(interval_hours).hours()
+    return job
+
 
 params = config()
 
-mode = params['env']
-interval = 1
-cronDir = os.getcwd();
-#The number of hours before next execution of the next job as set in the database.ini file
-if 'cron_interval'in params:
-    interval = int(params['cron_interval'])
+mode = params["env"]
+pipeline_interval = int(params.get("cron_interval", DEFAULT_PIPELINE_INTERVAL_HOURS))
+cleanup_interval = int(
+    params.get(
+        "known_test_uid_cleanup_interval",
+        params.get("cleanup_cron_interval", 0),
+    )
+)
+cleanup_max_rows = int(
+    params.get("known_test_uid_cleanup_max_rows", 100)
+)
+cron_dir = os.getcwd()
 
 try:
-# Set The User To Run The Cron Job
     cron = CronTab(user=True)
-# Set The Command To Run The Data Pipeline script and activate the virtual environment
-    if cronDir is not None:
-        job = cron.new(command='cd {0} && env/bin/python -m kedro run --env={1}'.format(cronDir,mode))
-    else:
-        logging.info('Please specify directory to find your kedro project in your database.ini file')
+
+    if not cron_dir:
+        logging.info(
+            "Please specify directory to find your kedro project in your database.ini file"
+        )
         sys.exit()
-    # Set The Time For The Cron Job
-    # Use job.minute for quick testing
-    job.every(interval).hours()
-    # Write the Job To CronTab
-    cron.write( user=True )
+
+    pipeline_comment = f"neotree-pipeline-{mode}"
+    pipeline_command = _build_kedro_command(cron_dir, mode, "run")
+    _replace_job(cron, pipeline_comment, pipeline_command, pipeline_interval)
+
+    if cleanup_interval > 0:
+        cleanup_comment = f"neotree-known-test-uid-cleanup-{mode}"
+        cleanup_args = f"--max-rows-per-uid {cleanup_max_rows}"
+        cleanup_command = _build_kedro_command(
+            cron_dir,
+            mode,
+            "purge-known-test-uids",
+            cleanup_args,
+        )
+        _replace_job(cron, cleanup_comment, cleanup_command, cleanup_interval)
+
+    cron.write(user=True)
 
 except Exception as e:
     logging.error("!!Cron Job Failed To Start Due To Errors: ")
     logging.error(formatError(e))
     sys.exit(1)
-

--- a/automation.py
+++ b/automation.py
@@ -7,6 +7,7 @@ import sys
 
 
 DEFAULT_PIPELINE_INTERVAL_HOURS = 6
+DEFAULT_SOURCE_UID_PREFLIGHT_MAX_ROWS = 100
 
 
 def _build_kedro_command(project_dir, env, subcommand, extra_args=""):
@@ -14,6 +15,17 @@ def _build_kedro_command(project_dir, env, subcommand, extra_args=""):
     if extra_args:
         command = f"{command} {extra_args}"
     return command
+
+
+def _build_pipeline_preflight_command(project_dir, env, max_rows_per_uid):
+    preflight_command = _build_kedro_command(
+        project_dir,
+        env,
+        "purge-known-test-uids-source-only",
+        f"--max-rows-per-uid {max_rows_per_uid}",
+    )
+    pipeline_command = _build_kedro_command(project_dir, env, "run")
+    return f"{preflight_command} && {pipeline_command}"
 
 
 def _replace_job(cron, comment, command, interval_hours):
@@ -27,14 +39,8 @@ params = config()
 
 mode = params["env"]
 pipeline_interval = int(params.get("cron_interval", DEFAULT_PIPELINE_INTERVAL_HOURS))
-cleanup_interval = int(
-    params.get(
-        "known_test_uid_cleanup_interval",
-        params.get("cleanup_cron_interval", 0),
-    )
-)
-cleanup_max_rows = int(
-    params.get("known_test_uid_cleanup_max_rows", 100)
+source_preflight_max_rows = int(
+    params.get("known_test_uid_cleanup_max_rows", DEFAULT_SOURCE_UID_PREFLIGHT_MAX_ROWS)
 )
 cron_dir = os.getcwd()
 
@@ -48,19 +54,12 @@ try:
         sys.exit()
 
     pipeline_comment = f"neotree-pipeline-{mode}"
-    pipeline_command = _build_kedro_command(cron_dir, mode, "run")
+    pipeline_command = _build_pipeline_preflight_command(
+        cron_dir,
+        mode,
+        source_preflight_max_rows,
+    )
     _replace_job(cron, pipeline_comment, pipeline_command, pipeline_interval)
-
-    if cleanup_interval > 0:
-        cleanup_comment = f"neotree-known-test-uid-cleanup-{mode}"
-        cleanup_args = f"--max-rows-per-uid {cleanup_max_rows}"
-        cleanup_command = _build_kedro_command(
-            cron_dir,
-            mode,
-            "purge-known-test-uids",
-            cleanup_args,
-        )
-        _replace_job(cron, cleanup_comment, cleanup_command, cleanup_interval)
 
     cron.write(user=True)
 

--- a/conf/common/config.py
+++ b/conf/common/config.py
@@ -19,50 +19,52 @@ else:
     logs_dir = Path(str(os.getcwd()+'/logs'))
     logs_dir.mkdir(exist_ok=True);
 
-env = None
-if len(sys.argv) >= 3:
-    env = sys.argv[2]
-    env = env.split('=')
-    if(len(env)) >1:
-        env = env[1];
-else:
-    log.error("Please include environment arguement (e.g. $ kedro run --env=dev)")
-    sys.exit()
-if env is not None:       
-    def config(filename='conf/local/database.ini'):
-        cwd = os.getcwd();
-        #logs_dir = str(cwd+'/logs')
-        
-        if env == "prod":
-            section = 'postgresql_prod'
-        elif env == "stage":
-            section = 'postgresql_stage'
-        elif env == "dev":
-            section = 'postgresql_dev'
-        elif env == "demo":
-            section = 'postgresql_demo'
+def _get_env_from_argv():
+    for arg in sys.argv:
+        if arg.startswith("--env="):
+            return arg.split("=", 1)[1]
+    return None
 
-        else:
-            log.error("{0} is not a valid arguement: Valid arguements are (dev or stage or prod or demo)".format(env))
-            sys.exit()
 
-         # create a parser
-        parser = ConfigParser()
-        # read config file
-        parser.read(filename)
+def config(filename='conf/local/database.ini'):
+    env = _get_env_from_argv()
+    if env is None:
+        log.error("Please include environment arguement (e.g. $ kedro run --env=dev)")
+        sys.exit()
 
-        # get section, default to postgresql
-        db = {}
-       
-        if parser.has_section(section):
-            params = parser.items(section)
-        # add environment to global params for use by other functions
-            db['env'] = env
-            for param in params:
-                db[param[0]] = param[1];
-        else:
-            log.error('Section {0} not found in the {1} file'.format(section, filename))
-            sys.exit()
-        return db
+    cwd = os.getcwd();
+    #logs_dir = str(cwd+'/logs')
+
+    if env == "prod":
+        section = 'postgresql_prod'
+    elif env == "stage":
+        section = 'postgresql_stage'
+    elif env == "dev":
+        section = 'postgresql_dev'
+    elif env == "demo":
+        section = 'postgresql_demo'
+
+    else:
+        log.error("{0} is not a valid arguement: Valid arguements are (dev or stage or prod or demo)".format(env))
+        sys.exit()
+
+     # create a parser
+    parser = ConfigParser()
+    # read config file
+    parser.read(filename)
+
+    # get section, default to postgresql
+    db = {}
+
+    if parser.has_section(section):
+        params = parser.items(section)
+    # add environment to global params for use by other functions
+        db['env'] = env
+        for param in params:
+            db[param[0]] = param[1];
+    else:
+        log.error('Section {0} not found in the {1} file'.format(section, filename))
+        sys.exit()
+    return db
 
    

--- a/conf/common/sql_functions.py
+++ b/conf/common/sql_functions.py
@@ -12,7 +12,6 @@ import numpy as np
 from conf.common.logger import setup_logger
 from conf.common.format_error import formatError
 from .config import config
-from data_pipeline.pipelines.data_engineering.utils.field_info import load_json_for_comparison
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -491,6 +490,8 @@ def is_date_column_by_name(column_name: str, table_name: str = '') -> bool:
     # Check field metadata if available and table_name provided
     if table_name:
         try:
+            from data_pipeline.pipelines.data_engineering.utils.field_info import load_json_for_comparison
+
             schema = load_json_for_comparison(table_name)
             if schema:
                 # Build field lookup
@@ -1126,6 +1127,8 @@ def transform_dataframe_with_field_info(df, table_name):
     """
 
     # Load field info using table_name as script
+    from data_pipeline.pipelines.data_engineering.utils.field_info import load_json_for_comparison
+
     schema = load_json_for_comparison(table_name)
     if not schema:
         logging.info(f"No field info found for {table_name}, skipping transformation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.kedro]
 package_name = "data_pipeline"
 project_name = "Neotree Data Pipeline Kedro"
-project_version = "0.17.0"
+kedro_init_version = "0.18.14"
 
 [tool.isort]
 multi_line_output = 3

--- a/src/data_pipeline/cli.py
+++ b/src/data_pipeline/cli.py
@@ -221,6 +221,14 @@ def run(
     node_names = _get_values_as_tuple(node_names) if node_names else node_names
 
     package_name = str(Path(__file__).resolve().parent.name)
+    # Preflight cleanup for known test UIDs before running the pipeline.
+    if env:
+        _bootstrap_legacy_env_arg(env)
+        from data_pipeline.pipelines.data_engineering.queries.data_fix import (
+            purge_known_test_uids_source_only as purge_known_test_uids_source_only_job,
+        )
+        purge_known_test_uids_source_only_job()
+
     with KedroSession.create(package_name, env=env, extra_params=params) as session:
         session.run(
             tags=tag,

--- a/src/data_pipeline/cli.py
+++ b/src/data_pipeline/cli.py
@@ -1,6 +1,7 @@
 
 """Command line tools for manipulating a Kedro project.
 Intended to be invoked via `kedro`."""
+import logging
 import os
 import sys
 from itertools import chain
@@ -275,29 +276,152 @@ def purge_uid(env, target_uid, schemas, candidate_columns, execute, confirm_uid)
     from data_pipeline.pipelines.data_engineering.queries.data_fix import (
         purge_uid_records,
     )
-
-    results = purge_uid_records(
-        uid=target_uid,
-        schemas=schemas or None,
-        candidate_columns=candidate_columns or None,
-        dry_run=not execute,
-    )
-
-    action = "Deleted" if execute else "Matched"
-    click.echo(
-        f"{action} {results['affected_rows']} row(s) across "
-        f"{results['affected_tables']} table(s); "
-        f"scanned {results['scanned_tables']} table(s)."
-    )
-
-    for match in results["matches"]:
-        click.echo(
-            f"{match['schema']}.{match['table']}: "
-            f"{match['rows']} row(s) via {', '.join(match['match_sources'])}"
+    try:
+        scan_results = purge_uid_records(
+            uid=target_uid,
+            schemas=schemas or None,
+            candidate_columns=candidate_columns or None,
+            dry_run=True,
         )
 
-    if not execute:
-        click.echo("Dry run only. Re-run with --execute to delete matching rows.")
+        if not execute:
+            click.echo(
+                f"Matched {scan_results['affected_rows']} row(s) across "
+                f"{scan_results['affected_tables']} table(s); "
+                f"scanned {scan_results['scanned_tables']} table(s)."
+            )
+            for table_name in scan_results["affected_table_names"]:
+                click.echo(table_name)
+            click.echo("Dry run only. Re-run with --execute to delete matching rows.")
+            return
+
+        if not scan_results["matches"]:
+            click.echo("No matching rows found. Nothing to delete.")
+            return
+
+        delete_results = purge_uid_records(
+            uid=target_uid,
+            schemas=schemas or None,
+            candidate_columns=candidate_columns or None,
+            dry_run=False,
+            table_matches=scan_results["matches"],
+        )
+        click.echo(
+            f"Deleted {delete_results['affected_rows']} row(s) across "
+            f"{delete_results['affected_tables']} table(s); "
+            f"scanned {scan_results['scanned_tables']} table(s)."
+        )
+        for table_name in delete_results["affected_table_names"]:
+            click.echo(table_name)
+    except Exception:
+        logging.exception("Manual UID cleanup failed for uid '%s'", target_uid)
+        raise KedroCliError(
+            "UID cleanup failed. Check the existing error log for details."
+        )
+
+
+@cli.command("purge-known-test-uids")
+@click.option("--env", required=True, help=ENV_ARG_HELP)
+@click.option(
+    "--schema",
+    "schemas",
+    multiple=True,
+    help="Schema to scan. Defaults to public, derived, and scratch.",
+)
+@click.option(
+    "--column",
+    "candidate_columns",
+    multiple=True,
+    help="Candidate UID column name. Defaults include uid and NeoTree ID variants.",
+)
+@click.option(
+    "--max-rows-per-uid",
+    default=100,
+    show_default=True,
+    type=int,
+    help="Safety cutoff. Skip deletion when a known test UID exceeds this match count.",
+)
+def purge_known_test_uids(env, schemas, candidate_columns, max_rows_per_uid):
+    """Purge the scheduled allowlist of known test UIDs."""
+    _bootstrap_legacy_env_arg(env)
+
+    from data_pipeline.pipelines.data_engineering.queries.data_fix import (
+        KNOWN_TEST_UIDS,
+        purge_known_test_uids as purge_known_test_uids_job,
+    )
+
+    try:
+        results = purge_known_test_uids_job(
+            schemas=schemas or None,
+            candidate_columns=candidate_columns or None,
+            max_rows_per_uid=max_rows_per_uid,
+        )
+        click.echo(
+            f"Checked {results['uids_checked']} known test UID(s); "
+            f"deleted {results['uids_deleted']}, skipped {results['uids_skipped']}, "
+            f"removed {results['total_rows_deleted']} row(s)."
+        )
+        click.echo(f"Allowlist: {', '.join(KNOWN_TEST_UIDS)}")
+        for result in results["results"]:
+            click.echo(
+                f"{result['uid']}: {result['status']} ({result['rows']} row(s))"
+            )
+    except Exception:
+        logging.exception("Scheduled known test UID cleanup failed")
+        raise KedroCliError(
+            "Known test UID cleanup failed. Check the existing error log for details."
+        )
+
+
+@cli.command("purge-known-test-uids-source-only")
+@click.option("--env", required=True, help=ENV_ARG_HELP)
+@click.option(
+    "--column",
+    "candidate_columns",
+    multiple=True,
+    help="Candidate UID column name. Defaults include uid and NeoTree ID variants.",
+)
+@click.option(
+    "--max-rows-per-uid",
+    default=100,
+    show_default=True,
+    type=int,
+    help="Safety cutoff. Skip deletion when a known test UID exceeds this match count.",
+)
+def purge_known_test_uids_source_only(env, candidate_columns, max_rows_per_uid):
+    """Purge known test UIDs only from source session tables before pipeline execution."""
+    _bootstrap_legacy_env_arg(env)
+
+    from data_pipeline.constants import SOURCE_UID_CLEANUP_TABLES
+    from data_pipeline.pipelines.data_engineering.queries.data_fix import (
+        KNOWN_TEST_UIDS,
+        purge_known_test_uids_source_only as purge_known_test_uids_source_only_job,
+    )
+
+    try:
+        results = purge_known_test_uids_source_only_job(
+            candidate_columns=candidate_columns or None,
+            max_rows_per_uid=max_rows_per_uid,
+        )
+        click.echo(
+            f"Checked {results['uids_checked']} known test UID(s); "
+            f"deleted {results['uids_deleted']}, skipped {results['uids_skipped']}, "
+            f"removed {results['total_rows_deleted']} row(s) from source tables."
+        )
+        click.echo(f"Allowlist: {', '.join(KNOWN_TEST_UIDS)}")
+        click.echo(
+            "Source tables: "
+            + ", ".join(f"{schema}.{table}" for schema, table in SOURCE_UID_CLEANUP_TABLES)
+        )
+        for result in results["results"]:
+            click.echo(
+                f"{result['uid']}: {result['status']} ({result['rows']} row(s))"
+            )
+    except Exception:
+        logging.exception("Source-only known test UID cleanup failed")
+        raise KedroCliError(
+            "Source-only known test UID cleanup failed. Check the existing error log for details."
+        )
 
 
 cli.add_command(pipeline_group)

--- a/src/data_pipeline/cli.py
+++ b/src/data_pipeline/cli.py
@@ -2,6 +2,7 @@
 """Command line tools for manipulating a Kedro project.
 Intended to be invoked via `kedro`."""
 import os
+import sys
 from itertools import chain
 from pathlib import Path
 from typing import Dict, Iterable, Tuple
@@ -125,6 +126,28 @@ def _try_convert_to_numeric(value):
     return int(value) if value.is_integer() else value
 
 
+def _bootstrap_legacy_env_arg(env: str) -> None:
+    """Keep legacy config parsing working for utility commands."""
+    normalized_env_arg = f"--env={env}"
+    current_argv = list(sys.argv)
+
+    rebuilt_argv = current_argv[:2] + [normalized_env_arg]
+    skip_next = False
+
+    for arg in current_argv[2:]:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--env":
+            skip_next = True
+            continue
+        if arg.startswith("--env="):
+            continue
+        rebuilt_argv.append(arg)
+
+    sys.argv = rebuilt_argv
+
+
 @click.group(context_settings=CONTEXT_SETTINGS, name=__file__)
 def cli():
     """Command line tools for manipulating a Kedro project."""
@@ -208,6 +231,73 @@ def run(
             load_versions=load_version,
             pipeline_name=pipeline,
         )
+
+
+@cli.command("purge-uid")
+@click.option("--env", required=True, help=ENV_ARG_HELP)
+@click.option(
+    "--uid",
+    "target_uid",
+    required=True,
+    help="UID/NUID value to scan for and remove.",
+)
+@click.option(
+    "--schema",
+    "schemas",
+    multiple=True,
+    help="Schema to scan. Defaults to public and derived.",
+)
+@click.option(
+    "--column",
+    "candidate_columns",
+    multiple=True,
+    help="Candidate UID column name. Defaults to uid/nuid/neotree_id variants.",
+)
+@click.option(
+    "--execute",
+    is_flag=True,
+    help="Delete matching rows. Without this flag, the command only reports matches.",
+)
+@click.option(
+    "--confirm-uid",
+    default="",
+    help="Required with --execute. Must exactly match --uid.",
+)
+def purge_uid(env, target_uid, schemas, candidate_columns, execute, confirm_uid):
+    """Scan for a test UID/NUID and optionally delete it across database tables."""
+    if execute and confirm_uid != target_uid:
+        raise KedroCliError(
+            "--execute requires --confirm-uid to exactly match the value passed to --uid."
+        )
+
+    _bootstrap_legacy_env_arg(env)
+
+    from data_pipeline.pipelines.data_engineering.queries.data_fix import (
+        purge_uid_records,
+    )
+
+    results = purge_uid_records(
+        uid=target_uid,
+        schemas=schemas or None,
+        candidate_columns=candidate_columns or None,
+        dry_run=not execute,
+    )
+
+    action = "Deleted" if execute else "Matched"
+    click.echo(
+        f"{action} {results['affected_rows']} row(s) across "
+        f"{results['affected_tables']} table(s); "
+        f"scanned {results['scanned_tables']} table(s)."
+    )
+
+    for match in results["matches"]:
+        click.echo(
+            f"{match['schema']}.{match['table']}: "
+            f"{match['rows']} row(s) via {', '.join(match['match_sources'])}"
+        )
+
+    if not execute:
+        click.echo("Dry run only. Re-run with --execute to delete matching rows.")
 
 
 cli.add_command(pipeline_group)

--- a/src/data_pipeline/constants.py
+++ b/src/data_pipeline/constants.py
@@ -1,0 +1,8 @@
+"""Project-wide constants."""
+
+KNOWN_TEST_UIDS = ("AAAA-111111",)
+
+SOURCE_UID_CLEANUP_TABLES = (
+    ("public", "sessions"),
+    ("public", "clean_sessions"),
+)

--- a/src/data_pipeline/hooks.py
+++ b/src/data_pipeline/hooks.py
@@ -4,7 +4,6 @@ from typing import Iterable
 from kedro.config import ConfigLoader
 from kedro.framework.hooks import hook_impl
 from kedro.io import DataCatalog
-from data_pipeline.pipelines import data_engineering as de
 
 
 
@@ -17,6 +16,8 @@ class ProjectHooks:
             A mapping from a pipeline name to a ``Pipeline`` object.
 
         """
+        from data_pipeline.pipelines import data_engineering as de
+
         data_engineering_pipeline = de.create_pipeline();
 
         return {

--- a/src/data_pipeline/pipelines/data_engineering/__init__.py
+++ b/src/data_pipeline/pipelines/data_engineering/__init__.py
@@ -31,4 +31,7 @@ just for illustrating basic Kedro features.
 PLEASE DELETE THIS FILE ONCE YOU START WORKING ON YOUR OWN PROJECT!
 """
 
-from .pipeline import create_pipeline  # NOQA
+def create_pipeline(*args, **kwargs):
+    from .pipeline import create_pipeline as _create_pipeline
+
+    return _create_pipeline(*args, **kwargs)

--- a/src/data_pipeline/pipelines/data_engineering/queries/data_fix.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/data_fix.py
@@ -14,13 +14,395 @@ Available Functions:
 9. rebuild_table_dry_run(table, schema) - Preview rebuild without executing
 10. rebuild_table_to_remove_dropped_columns(table, schema) - Reclaim dropped columns
 11. fix_column_limit_error(table, schema, auto_rebuild) - Diagnose/fix 1600 column limit
+12. purge_uid_records(uid, ...) - Scan/delete a test UID or NUID across database tables
 """
 
 import logging
-from conf.common.sql_functions import inject_sql_procedure, inject_sql_with_return,inject_sql
+from conf.common.sql_functions import (
+    engine,
+    inject_sql,
+    inject_sql_procedure,
+    inject_sql_with_return,
+    text,
+)
 from data_pipeline.pipelines.data_engineering.queries.check_table_exists_sql import table_exists
 from data_pipeline.pipelines.data_engineering.utils.field_info import load_json_for_comparison
 import re
+
+
+DEFAULT_UID_MATCH_COLUMNS = ("uid", "nuid", "neotree_id", "neotreeid")
+DEFAULT_JSON_UID_KEYS = (
+    "UID",
+    "NeoTreeID",
+    "NeoTreeIDBC",
+    "NUID_BC",
+    "NUID_M",
+    "NUID_S",
+)
+KNOWN_TEST_UIDS = ("AAAA-111111",)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + str(identifier).replace('"', '""') + '"'
+
+
+def _escape_sql_literal(value: str) -> str:
+    return str(value).replace("'", "''")
+
+
+def _build_uid_filter(columns, uid: str) -> str:
+    escaped_uid = _escape_sql_literal(uid)
+    return " OR ".join(
+        f"{_quote_identifier(column)} = '{escaped_uid}'" for column in columns
+    )
+
+
+def _build_json_uid_filter(data_column: str, uid: str) -> str:
+    escaped_uid = _escape_sql_literal(uid)
+    quoted_data_column = _quote_identifier(data_column)
+    object_entry_matches = " OR ".join(
+        f"{quoted_data_column}->'entries'->'{json_key}'->'values'->'value'->>0 = '{escaped_uid}'"
+        for json_key in DEFAULT_JSON_UID_KEYS
+    )
+    old_format_key_list = ", ".join(
+        f"'{_escape_sql_literal(json_key)}'" for json_key in DEFAULT_JSON_UID_KEYS
+    )
+
+    return f"""(
+        {quoted_data_column}->>'uid' = '{escaped_uid}'
+        OR {object_entry_matches}
+        OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(
+                CASE
+                    WHEN jsonb_typeof({quoted_data_column}->'entries') = 'array'
+                    THEN {quoted_data_column}->'entries'
+                    ELSE '[]'::jsonb
+                END
+            ) AS entry
+            WHERE entry->>'key' IN ({old_format_key_list})
+            AND (
+                entry->'values'->0->>'value' = '{escaped_uid}'
+                OR entry->'values'->'value'->>0 = '{escaped_uid}'
+            )
+        )
+    )"""
+
+
+def _get_uid_table_matches(schemas=None, candidate_columns=None):
+    schemas = tuple(schemas or ("public", "derived"))
+    candidate_columns = tuple(candidate_columns or DEFAULT_UID_MATCH_COLUMNS)
+
+    schema_sql = ", ".join(f"'{_escape_sql_literal(schema)}'" for schema in schemas)
+    column_sql = ", ".join(
+        f"'{_escape_sql_literal(column.lower())}'" for column in candidate_columns
+    )
+
+    query = f"""
+        SELECT DISTINCT
+            c.table_schema,
+            c.table_name,
+            c.column_name,
+            c.data_type
+        FROM information_schema.columns c
+        INNER JOIN information_schema.tables t
+            ON c.table_schema = t.table_schema
+            AND c.table_name = t.table_name
+        WHERE t.table_type = 'BASE TABLE'
+        AND c.table_schema IN ({schema_sql})
+        AND (
+            LOWER(c.column_name) IN ({column_sql})
+            OR LOWER(c.column_name) = 'data'
+        )
+        ORDER BY c.table_schema, c.table_name, c.column_name;
+    """
+
+    grouped_matches = {}
+    for schema_name, table_name, column_name, data_type in inject_sql_with_return(query):
+        spec = grouped_matches.setdefault(
+            (schema_name, table_name),
+            {"columns": [], "json_columns": []},
+        )
+        if str(column_name).lower() in candidate_columns:
+            spec["columns"].append(column_name)
+        if (
+            str(column_name).lower() == "data"
+            and str(data_type).lower() in ("json", "jsonb")
+        ):
+            spec["json_columns"].append(column_name)
+
+    return grouped_matches
+
+
+def _build_table_match_specs(uid: str, schemas=None, candidate_columns=None):
+    schemas = tuple(schemas or ("public", "derived"))
+    candidate_columns = tuple(candidate_columns or DEFAULT_UID_MATCH_COLUMNS)
+    grouped_matches = _get_uid_table_matches(schemas, candidate_columns)
+    table_specs = []
+
+    for (schema_name, table_name), match_config in grouped_matches.items():
+        filters = []
+        if match_config["columns"]:
+            filters.append(_build_uid_filter(match_config["columns"], uid))
+        for json_column in match_config["json_columns"]:
+            filters.append(_build_json_uid_filter(json_column, uid))
+
+        if not filters:
+            continue
+
+        table_specs.append(
+            {
+                "schema": schema_name,
+                "table": table_name,
+                "columns": match_config["columns"],
+                "json_columns": match_config["json_columns"],
+                "where_clause": " OR ".join(f"({where_filter})" for where_filter in filters),
+            }
+        )
+
+    schema_priority = {"derived": 0, "public": 1}
+    table_specs.sort(
+        key=lambda spec: (
+            schema_priority.get(spec["schema"], 99),
+            spec["schema"],
+            spec["table"],
+        )
+    )
+    return table_specs
+
+
+def _execute_scalar_queries_in_transaction(query_specs):
+    if not engine or not text:
+        raise RuntimeError("Database engine not initialized")
+
+    results = []
+    with engine.begin() as connection:  # type: ignore[union-attr]
+        for query_spec in query_specs:
+            scalar_result = connection.execute(text(query_spec["sql"])).scalar()
+            row_count = int(scalar_result) if scalar_result else 0
+            results.append(
+                {
+                    "schema": query_spec["schema"],
+                    "table": query_spec["table"],
+                    "columns": query_spec["columns"],
+                    "json_columns": query_spec["json_columns"],
+                    "rows": row_count,
+                }
+            )
+
+    return results
+
+
+def purge_uid_records(
+    uid: str,
+    schemas=None,
+    candidate_columns=None,
+    dry_run: bool = True,
+):
+    """
+    Scan or delete a specific UID/NUID across database tables.
+
+    This is intended for removing test records that were created in production
+    or stage environments and have propagated into raw and derived tables.
+
+    Args:
+        uid: UID/NUID value to match exactly
+        schemas: Schemas to inspect. Defaults to ('public', 'derived')
+        candidate_columns: Candidate column names to match exactly. Defaults to
+            uid/nuid/neotree id variants.
+        dry_run: When True, only count matches. When False, delete them.
+
+    Returns:
+        Dict with per-table matches and total rows affected.
+    """
+    if not uid or not str(uid).strip():
+        raise ValueError("uid must be a non-empty string")
+
+    table_specs = _build_table_match_specs(uid, schemas, candidate_columns)
+    matches = []
+    total_rows = 0
+
+    if dry_run:
+        query_results = []
+        for spec in table_specs:
+            qualified_table = (
+                f"{_quote_identifier(spec['schema'])}.{_quote_identifier(spec['table'])}"
+            )
+            query = (
+                f"SELECT COUNT(*) FROM {qualified_table} WHERE {spec['where_clause']};"
+            )
+            result = inject_sql_with_return(query)
+            row_count = int(result[0][0]) if result and result[0] and result[0][0] else 0
+            query_results.append(
+                {
+                    "schema": spec["schema"],
+                    "table": spec["table"],
+                    "columns": spec["columns"],
+                    "json_columns": spec["json_columns"],
+                    "rows": row_count,
+                }
+            )
+    else:
+        query_specs = []
+        for spec in table_specs:
+            qualified_table = (
+                f"{_quote_identifier(spec['schema'])}.{_quote_identifier(spec['table'])}"
+            )
+            query_specs.append(
+                {
+                    "schema": spec["schema"],
+                    "table": spec["table"],
+                    "columns": spec["columns"],
+                    "json_columns": spec["json_columns"],
+                    "sql": f"""
+                        WITH deleted AS (
+                            DELETE FROM {qualified_table}
+                            WHERE {spec['where_clause']}
+                            RETURNING 1
+                        )
+                        SELECT COUNT(*) FROM deleted;
+                    """,
+                }
+            )
+        query_results = _execute_scalar_queries_in_transaction(query_specs)
+
+    for result in query_results:
+        row_count = result["rows"]
+        if row_count <= 0:
+            continue
+
+        match_sources = []
+        if result["columns"]:
+            match_sources.append(", ".join(result["columns"]))
+        if result["json_columns"]:
+            match_sources.append(f"json:{', '.join(result['json_columns'])}")
+
+        matches.append(
+            {
+                "schema": result["schema"],
+                "table": result["table"],
+                "columns": result["columns"],
+                "json_columns": result["json_columns"],
+                "rows": row_count,
+                "match_sources": match_sources,
+            }
+        )
+        total_rows += row_count
+
+    action = "Found" if dry_run else "Deleted"
+    logging.info(
+        "%s %s matching row(s) for UID '%s' across %s table(s)",
+        action,
+        total_rows,
+        uid,
+        len(matches),
+    )
+
+    for match in matches:
+        logging.info(
+            "%s.%s via %s -> %s row(s)",
+            match["schema"],
+            match["table"],
+            ", ".join(match["match_sources"]),
+            match["rows"],
+        )
+
+    return {
+        "uid": uid,
+        "dry_run": dry_run,
+        "scanned_tables": len(table_specs),
+        "affected_tables": len(matches),
+        "affected_rows": total_rows,
+        "matches": matches,
+    }
+
+
+def purge_known_test_uids(
+    schemas=None,
+    candidate_columns=None,
+    max_rows_per_uid: int = 100,
+):
+    """
+    Purge a fixed allowlist of known test UIDs.
+
+    This is intended for scheduled maintenance jobs. Each UID is scanned first
+    and only deleted when matches are present and under the configured safety
+    threshold.
+
+    Args:
+        schemas: Schemas to inspect. Defaults to ('public', 'derived')
+        candidate_columns: Candidate column names to match exactly.
+        max_rows_per_uid: Abort deletion for a UID if dry run exceeds this count.
+
+    Returns:
+        Summary dict with per-UID outcomes.
+    """
+    if max_rows_per_uid <= 0:
+        raise ValueError("max_rows_per_uid must be greater than zero")
+
+    summary = {
+        "uids_checked": len(KNOWN_TEST_UIDS),
+        "uids_deleted": 0,
+        "uids_skipped": 0,
+        "total_rows_deleted": 0,
+        "results": [],
+    }
+
+    for uid in KNOWN_TEST_UIDS:
+        scan_result = purge_uid_records(
+            uid=uid,
+            schemas=schemas,
+            candidate_columns=candidate_columns,
+            dry_run=True,
+        )
+
+        if scan_result["affected_rows"] == 0:
+            summary["results"].append(
+                {
+                    "uid": uid,
+                    "status": "not_found",
+                    "rows": 0,
+                    "matches": [],
+                }
+            )
+            continue
+
+        if scan_result["affected_rows"] > max_rows_per_uid:
+            logging.warning(
+                "Skipping purge for UID '%s': dry run found %s row(s), above safeguard of %s",
+                uid,
+                scan_result["affected_rows"],
+                max_rows_per_uid,
+            )
+            summary["uids_skipped"] += 1
+            summary["results"].append(
+                {
+                    "uid": uid,
+                    "status": "skipped_max_rows",
+                    "rows": scan_result["affected_rows"],
+                    "matches": scan_result["matches"],
+                }
+            )
+            continue
+
+        delete_result = purge_uid_records(
+            uid=uid,
+            schemas=schemas,
+            candidate_columns=candidate_columns,
+            dry_run=False,
+        )
+        summary["uids_deleted"] += 1
+        summary["total_rows_deleted"] += delete_result["affected_rows"]
+        summary["results"].append(
+            {
+                "uid": uid,
+                "status": "deleted",
+                "rows": delete_result["affected_rows"],
+                "matches": delete_result["matches"],
+            }
+        )
+
+    return summary
 
 
 

--- a/src/data_pipeline/pipelines/data_engineering/queries/data_fix.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/data_fix.py
@@ -69,8 +69,9 @@ def _build_uid_filter(columns, uid: str) -> str:
 def _build_json_uid_filter(data_column: str, uid: str) -> str:
     escaped_uid = _escape_sql_literal(uid)
     quoted_data_column = _quote_identifier(data_column)
+    json_data_column = f"({quoted_data_column})::jsonb"
     object_entry_matches = " OR ".join(
-        f"{quoted_data_column}->'entries'->'{json_key}'->'values'->'value'->>0 = '{escaped_uid}'"
+        f"{json_data_column}->'entries'->'{json_key}'->'values'->'value'->>0 = '{escaped_uid}'"
         for json_key in DEFAULT_JSON_UID_KEYS
     )
     old_format_key_list = ", ".join(
@@ -78,14 +79,14 @@ def _build_json_uid_filter(data_column: str, uid: str) -> str:
     )
 
     return f"""(
-        {quoted_data_column}->>'uid' = '{escaped_uid}'
+        {json_data_column}->>'uid' = '{escaped_uid}'
         OR {object_entry_matches}
         OR EXISTS (
             SELECT 1
             FROM jsonb_array_elements(
                 CASE
-                    WHEN jsonb_typeof({quoted_data_column}->'entries') = 'array'
-                    THEN {quoted_data_column}->'entries'
+                    WHEN jsonb_typeof({json_data_column}->'entries') = 'array'
+                    THEN {json_data_column}->'entries'
                     ELSE '[]'::jsonb
                 END
             ) AS entry
@@ -428,6 +429,7 @@ def _execute_scalar_queries_in_transaction(query_specs):
             row_count = int(scalar_result) if scalar_result else 0
             results.append(
                 {
+                    "uid": query_spec["uid"],
                     "schema": query_spec["schema"],
                     "table": query_spec["table"],
                     "columns": query_spec["columns"],
@@ -610,9 +612,9 @@ def purge_uid_records(
                     continue
                 query_specs.append(
                     {
+                        "uid": uid,
                         "schema": match["schema"],
                         "table": match["table"],
-                        "uid": uid,
                         "columns": spec["columns"],
                         "json_columns": spec["json_columns"],
                         "incremental_column": match.get("incremental_column"),
@@ -2606,4 +2608,3 @@ def fix_column_limit_error(table_name: str, schema: str = 'derived', auto_rebuil
         logging.warning("  3. Using JSONB for semi-structured data")
 
     return col_info['dropped'] > 0
-

--- a/src/data_pipeline/pipelines/data_engineering/queries/data_fix.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/data_fix.py
@@ -25,12 +25,15 @@ from conf.common.sql_functions import (
     inject_sql_with_return,
     text,
 )
+from data_pipeline.constants import KNOWN_TEST_UIDS, SOURCE_UID_CLEANUP_TABLES
 from data_pipeline.pipelines.data_engineering.queries.check_table_exists_sql import table_exists
 from data_pipeline.pipelines.data_engineering.utils.field_info import load_json_for_comparison
 import re
 
 
 DEFAULT_UID_MATCH_COLUMNS = ("uid", "nuid", "neotree_id", "neotreeid")
+DEFAULT_UID_MATCH_SCHEMAS = ("public", "derived", "scratch")
+DEFAULT_INCREMENTAL_COLUMNS = ("id", "ingested_at", "updated_at", "created_at")
 DEFAULT_JSON_UID_KEYS = (
     "UID",
     "NeoTreeID",
@@ -39,7 +42,7 @@ DEFAULT_JSON_UID_KEYS = (
     "NUID_M",
     "NUID_S",
 )
-KNOWN_TEST_UIDS = ("AAAA-111111",)
+UID_CLEANUP_TRACKING_TABLE = "uid_cleanup_scan_tracker"
 
 
 def _quote_identifier(identifier: str) -> str:
@@ -48,6 +51,12 @@ def _quote_identifier(identifier: str) -> str:
 
 def _escape_sql_literal(value: str) -> str:
     return str(value).replace("'", "''")
+
+
+def _nullable_sql_literal(value) -> str:
+    if value is None:
+        return "NULL"
+    return f"'{_escape_sql_literal(value)}'"
 
 
 def _build_uid_filter(columns, uid: str) -> str:
@@ -90,8 +99,8 @@ def _build_json_uid_filter(data_column: str, uid: str) -> str:
 
 
 def _get_uid_table_matches(schemas=None, candidate_columns=None):
-    schemas = tuple(schemas or ("public", "derived"))
-    candidate_columns = tuple(candidate_columns or DEFAULT_UID_MATCH_COLUMNS)
+    schemas = tuple(schemas or DEFAULT_UID_MATCH_SCHEMAS)
+    candidate_columns = _normalize_candidate_columns(candidate_columns)
 
     schema_sql = ", ".join(f"'{_escape_sql_literal(schema)}'" for schema in schemas)
     column_sql = ", ".join(
@@ -113,6 +122,11 @@ def _get_uid_table_matches(schemas=None, candidate_columns=None):
         AND (
             LOWER(c.column_name) IN ({column_sql})
             OR LOWER(c.column_name) = 'data'
+            OR LOWER(c.column_name) IN ('id', 'ingested_at', 'updated_at', 'created_at')
+        )
+        AND NOT (
+            c.table_schema = 'scratch'
+            AND c.table_name = '{UID_CLEANUP_TRACKING_TABLE}'
         )
         ORDER BY c.table_schema, c.table_name, c.column_name;
     """
@@ -130,13 +144,159 @@ def _get_uid_table_matches(schemas=None, candidate_columns=None):
             and str(data_type).lower() in ("json", "jsonb")
         ):
             spec["json_columns"].append(column_name)
+        if str(column_name).lower() in DEFAULT_INCREMENTAL_COLUMNS:
+            spec.setdefault("incremental_candidates", []).append(
+                {"column_name": column_name, "data_type": data_type}
+            )
 
     return grouped_matches
 
 
+def _normalize_candidate_columns(candidate_columns=None):
+    columns = tuple(candidate_columns or DEFAULT_UID_MATCH_COLUMNS)
+    normalized = []
+    seen = set()
+    for column in ("uid",) + columns:
+        lowered = str(column).lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        normalized.append(lowered)
+    return tuple(normalized)
+
+
+def _ensure_uid_cleanup_tracking_table():
+    inject_sql(
+        f"""
+        CREATE SCHEMA IF NOT EXISTS scratch;;
+        CREATE TABLE IF NOT EXISTS scratch.{UID_CLEANUP_TRACKING_TABLE} (
+            uid TEXT NOT NULL,
+            table_schema TEXT NOT NULL,
+            table_name TEXT NOT NULL,
+            affected_rows INTEGER NOT NULL DEFAULT 0,
+            scanned BOOLEAN NOT NULL DEFAULT FALSE,
+            deleted BOOLEAN NOT NULL DEFAULT FALSE,
+            skipped BOOLEAN NOT NULL DEFAULT FALSE,
+            last_scanned_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            last_deleted_at TIMESTAMP NULL,
+            incremental_column TEXT NULL,
+            last_incremental_value TEXT NULL,
+            error_message TEXT NULL,
+            PRIMARY KEY (uid, table_schema, table_name)
+        );;
+        ALTER TABLE scratch.{UID_CLEANUP_TRACKING_TABLE}
+            ADD COLUMN IF NOT EXISTS skipped BOOLEAN NOT NULL DEFAULT FALSE;;
+        ALTER TABLE scratch.{UID_CLEANUP_TRACKING_TABLE}
+            ADD COLUMN IF NOT EXISTS incremental_column TEXT NULL;;
+        ALTER TABLE scratch.{UID_CLEANUP_TRACKING_TABLE}
+            ADD COLUMN IF NOT EXISTS last_incremental_value TEXT NULL;;
+        """,
+        "ENSURE UID CLEANUP TRACKING TABLE",
+    )
+
+
+def _record_uid_cleanup_scan(uid: str, table_results, deleted: bool = False):
+    if not table_results:
+        return
+
+    values = []
+    for result in table_results:
+        deleted_sql = "TRUE" if deleted else "FALSE"
+        deleted_at_sql = "CURRENT_TIMESTAMP" if deleted else "NULL"
+        values.append(
+            "("
+            f"'{_escape_sql_literal(uid)}', "
+            f"'{_escape_sql_literal(result['schema'])}', "
+            f"'{_escape_sql_literal(result['table'])}', "
+            f"{int(result['rows'])}, "
+            "TRUE, "
+            f"{deleted_sql}, "
+            f"{'TRUE' if result.get('skipped') else 'FALSE'}, "
+            "CURRENT_TIMESTAMP, "
+            f"{deleted_at_sql}, "
+            f"{_nullable_sql_literal(result.get('incremental_column'))}, "
+            f"{_nullable_sql_literal(result.get('last_incremental_value'))}, "
+            "NULL"
+            ")"
+        )
+
+    inject_sql(
+        f"""
+        INSERT INTO scratch.{UID_CLEANUP_TRACKING_TABLE} (
+            uid,
+            table_schema,
+            table_name,
+            affected_rows,
+            scanned,
+            deleted,
+            skipped,
+            last_scanned_at,
+            last_deleted_at,
+            incremental_column,
+            last_incremental_value,
+            error_message
+        )
+        VALUES {", ".join(values)}
+        ON CONFLICT (uid, table_schema, table_name)
+        DO UPDATE SET
+            affected_rows = EXCLUDED.affected_rows,
+            scanned = TRUE,
+            deleted = EXCLUDED.deleted,
+            skipped = EXCLUDED.skipped,
+            last_scanned_at = CURRENT_TIMESTAMP,
+            last_deleted_at = EXCLUDED.last_deleted_at,
+            incremental_column = EXCLUDED.incremental_column,
+            last_incremental_value = EXCLUDED.last_incremental_value,
+            error_message = NULL;;
+        """,
+        "RECORD UID CLEANUP SCAN",
+    )
+
+
+def _record_uid_cleanup_error(uid: str, error_message: str):
+    _ensure_uid_cleanup_tracking_table()
+    inject_sql(
+        f"""
+        INSERT INTO scratch.{UID_CLEANUP_TRACKING_TABLE} (
+            uid,
+            table_schema,
+            table_name,
+            affected_rows,
+            scanned,
+            deleted,
+            skipped,
+            last_scanned_at,
+            last_deleted_at,
+            incremental_column,
+            last_incremental_value,
+            error_message
+        )
+        VALUES (
+            '{_escape_sql_literal(uid)}',
+            '__error__',
+            '__error__',
+            0,
+            FALSE,
+            FALSE,
+            FALSE,
+            CURRENT_TIMESTAMP,
+            NULL,
+            NULL,
+            NULL,
+            '{_escape_sql_literal(error_message)}'
+        )
+        ON CONFLICT (uid, table_schema, table_name)
+        DO UPDATE SET
+            last_scanned_at = CURRENT_TIMESTAMP,
+            error_message = EXCLUDED.error_message;;
+        """,
+        "RECORD UID CLEANUP ERROR",
+    )
+
+
 def _build_table_match_specs(uid: str, schemas=None, candidate_columns=None):
-    schemas = tuple(schemas or ("public", "derived"))
-    candidate_columns = tuple(candidate_columns or DEFAULT_UID_MATCH_COLUMNS)
+    schemas = tuple(schemas or DEFAULT_UID_MATCH_SCHEMAS)
+    candidate_columns = _normalize_candidate_columns(candidate_columns)
     grouped_matches = _get_uid_table_matches(schemas, candidate_columns)
     table_specs = []
 
@@ -156,6 +316,9 @@ def _build_table_match_specs(uid: str, schemas=None, candidate_columns=None):
                 "table": table_name,
                 "columns": match_config["columns"],
                 "json_columns": match_config["json_columns"],
+                "incremental_column": _select_incremental_column(
+                    match_config.get("incremental_candidates", [])
+                ),
                 "where_clause": " OR ".join(f"({where_filter})" for where_filter in filters),
             }
         )
@@ -169,6 +332,89 @@ def _build_table_match_specs(uid: str, schemas=None, candidate_columns=None):
         )
     )
     return table_specs
+
+
+def _filter_table_specs(table_specs, allowed_tables=None):
+    if not allowed_tables:
+        return table_specs
+
+    allowed_table_set = {
+        (schema_name.lower(), table_name.lower())
+        for schema_name, table_name in allowed_tables
+    }
+    return [
+        spec
+        for spec in table_specs
+        if (spec["schema"].lower(), spec["table"].lower()) in allowed_table_set
+    ]
+
+
+def _select_incremental_column(incremental_candidates):
+    if not incremental_candidates:
+        return None
+    priority = {name: index for index, name in enumerate(DEFAULT_INCREMENTAL_COLUMNS)}
+    ordered = sorted(
+        incremental_candidates,
+        key=lambda item: priority.get(str(item["column_name"]).lower(), 99),
+    )
+    return ordered[0]
+
+
+def _get_tracking_row(uid: str, schema: str, table: str):
+    result = inject_sql_with_return(
+        f"""
+        SELECT last_incremental_value
+        FROM scratch.{UID_CLEANUP_TRACKING_TABLE}
+        WHERE uid = '{_escape_sql_literal(uid)}'
+        AND table_schema = '{_escape_sql_literal(schema)}'
+        AND table_name = '{_escape_sql_literal(table)}';;
+        """
+    )
+    if not result:
+        return None
+    return result[0][0]
+
+
+def _fetch_latest_incremental_value(spec) -> str:
+    incremental = spec.get("incremental_column")
+    if not incremental:
+        return None
+
+    qualified_table = (
+        f"{_quote_identifier(spec['schema'])}.{_quote_identifier(spec['table'])}"
+    )
+    quoted_column = _quote_identifier(incremental["column_name"])
+    result = inject_sql_with_return(
+        f"""
+        SELECT {quoted_column}::text
+        FROM {qualified_table}
+        WHERE {quoted_column} IS NOT NULL
+        ORDER BY {quoted_column} DESC
+        LIMIT 1;;
+        """
+    )
+    if not result:
+        return None
+    return result[0][0]
+
+
+def _build_incremental_filter(spec, last_incremental_value: str):
+    incremental = spec.get("incremental_column")
+    if not incremental or last_incremental_value is None:
+        return None
+
+    column_name = _quote_identifier(incremental["column_name"])
+    data_type = str(incremental["data_type"]).lower()
+    escaped_value = _escape_sql_literal(last_incremental_value)
+
+    if "timestamp" in data_type or "date" in data_type or "time" in data_type:
+        literal = f"'{escaped_value}'::timestamp"
+    elif any(token in data_type for token in ("int", "numeric", "double", "real", "decimal")):
+        literal = escaped_value
+    else:
+        literal = f"'{escaped_value}'"
+
+    return f"{column_name} > {literal}"
 
 
 def _execute_scalar_queries_in_transaction(query_specs):
@@ -193,11 +439,115 @@ def _execute_scalar_queries_in_transaction(query_specs):
     return results
 
 
+def _build_delete_sql(qualified_table: str, where_clause: str, limit_rows: int) -> str:
+    return f"""
+        WITH rows_to_delete AS (
+            SELECT ctid
+            FROM {qualified_table}
+            WHERE {where_clause}
+            LIMIT {limit_rows}
+        ),
+        deleted AS (
+            DELETE FROM {qualified_table}
+            WHERE ctid IN (SELECT ctid FROM rows_to_delete)
+            RETURNING 1
+        )
+        SELECT COUNT(*) FROM deleted;
+    """
+
+
+def _build_match_result(result):
+    match_sources = []
+    if result["columns"]:
+        match_sources.append(", ".join(result["columns"]))
+    if result["json_columns"]:
+        match_sources.append(f"json:{', '.join(result['json_columns'])}")
+
+    return {
+        "schema": result["schema"],
+        "table": result["table"],
+        "table_name": f"{result['schema']}.{result['table']}",
+        "uid": result["uid"],
+        "columns": result["columns"],
+        "json_columns": result["json_columns"],
+        "rows": result["rows"],
+        "limit": result["rows"],
+        "scanned": True,
+        "skipped": result.get("skipped", False),
+        "incremental_column": result.get("incremental_column"),
+        "last_incremental_value": result.get("last_incremental_value"),
+        "effective_where_clause": result.get("effective_where_clause"),
+        "match_sources": match_sources,
+    }
+
+
+def _scan_uid_table_matches(uid: str, table_specs, use_tracking: bool = False):
+    query_results = []
+    for spec in table_specs:
+        qualified_table = (
+            f"{_quote_identifier(spec['schema'])}.{_quote_identifier(spec['table'])}"
+        )
+        effective_where_clause = spec["where_clause"]
+        last_incremental_value = _fetch_latest_incremental_value(spec)
+        skipped = False
+
+        if use_tracking and spec.get("incremental_column"):
+            previous_incremental_value = _get_tracking_row(
+                uid, spec["schema"], spec["table"]
+            )
+            if (
+                previous_incremental_value is not None
+                and last_incremental_value == previous_incremental_value
+            ):
+                skipped = True
+            else:
+                incremental_filter = _build_incremental_filter(
+                    spec, previous_incremental_value
+                )
+                if incremental_filter:
+                    effective_where_clause = (
+                        f"({spec['where_clause']}) AND ({incremental_filter})"
+                    )
+
+        if skipped:
+            row_count = 0
+        else:
+            query = (
+                f"SELECT COUNT(*) FROM {qualified_table} WHERE {effective_where_clause};"
+            )
+            result = inject_sql_with_return(query)
+            row_count = (
+                int(result[0][0]) if result and result[0] and result[0][0] else 0
+            )
+        query_results.append(
+            {
+                "schema": spec["schema"],
+                "table": spec["table"],
+                "uid": uid,
+                "columns": spec["columns"],
+                "json_columns": spec["json_columns"],
+                "incremental_column": (
+                    spec["incremental_column"]["column_name"]
+                    if spec.get("incremental_column")
+                    else None
+                ),
+                "last_incremental_value": last_incremental_value,
+                "effective_where_clause": effective_where_clause,
+                "skipped": skipped,
+                "rows": row_count,
+            }
+        )
+    return query_results
+
+
 def purge_uid_records(
     uid: str,
     schemas=None,
     candidate_columns=None,
     dry_run: bool = True,
+    table_matches=None,
+    use_tracking: bool = False,
+    allowed_tables=None,
 ):
     """
     Scan or delete a specific UID/NUID across database tables.
@@ -211,6 +561,8 @@ def purge_uid_records(
         candidate_columns: Candidate column names to match exactly. Defaults to
             uid/nuid/neotree id variants.
         dry_run: When True, only count matches. When False, delete them.
+        table_matches: Optional dry-run matches to delete without rescanning.
+        allowed_tables: Optional iterable of (schema, table) pairs to restrict scope.
 
     Returns:
         Dict with per-table matches and total rows affected.
@@ -218,103 +570,113 @@ def purge_uid_records(
     if not uid or not str(uid).strip():
         raise ValueError("uid must be a non-empty string")
 
-    table_specs = _build_table_match_specs(uid, schemas, candidate_columns)
-    matches = []
-    total_rows = 0
-
-    if dry_run:
-        query_results = []
-        for spec in table_specs:
-            qualified_table = (
-                f"{_quote_identifier(spec['schema'])}.{_quote_identifier(spec['table'])}"
-            )
-            query = (
-                f"SELECT COUNT(*) FROM {qualified_table} WHERE {spec['where_clause']};"
-            )
-            result = inject_sql_with_return(query)
-            row_count = int(result[0][0]) if result and result[0] and result[0][0] else 0
-            query_results.append(
-                {
-                    "schema": spec["schema"],
-                    "table": spec["table"],
-                    "columns": spec["columns"],
-                    "json_columns": spec["json_columns"],
-                    "rows": row_count,
-                }
-            )
-    else:
-        query_specs = []
-        for spec in table_specs:
-            qualified_table = (
-                f"{_quote_identifier(spec['schema'])}.{_quote_identifier(spec['table'])}"
-            )
-            query_specs.append(
-                {
-                    "schema": spec["schema"],
-                    "table": spec["table"],
-                    "columns": spec["columns"],
-                    "json_columns": spec["json_columns"],
-                    "sql": f"""
-                        WITH deleted AS (
-                            DELETE FROM {qualified_table}
-                            WHERE {spec['where_clause']}
-                            RETURNING 1
-                        )
-                        SELECT COUNT(*) FROM deleted;
-                    """,
-                }
-            )
-        query_results = _execute_scalar_queries_in_transaction(query_specs)
-
-    for result in query_results:
-        row_count = result["rows"]
-        if row_count <= 0:
-            continue
-
-        match_sources = []
-        if result["columns"]:
-            match_sources.append(", ".join(result["columns"]))
-        if result["json_columns"]:
-            match_sources.append(f"json:{', '.join(result['json_columns'])}")
-
-        matches.append(
-            {
-                "schema": result["schema"],
-                "table": result["table"],
-                "columns": result["columns"],
-                "json_columns": result["json_columns"],
-                "rows": row_count,
-                "match_sources": match_sources,
-            }
+    try:
+        _ensure_uid_cleanup_tracking_table()
+        table_specs = _filter_table_specs(
+            _build_table_match_specs(uid, schemas, candidate_columns),
+            allowed_tables=allowed_tables,
         )
-        total_rows += row_count
+        matches = []
+        total_rows = 0
 
-    action = "Found" if dry_run else "Deleted"
-    logging.info(
-        "%s %s matching row(s) for UID '%s' across %s table(s)",
-        action,
-        total_rows,
-        uid,
-        len(matches),
-    )
+        if dry_run:
+            query_results = _scan_uid_table_matches(
+                uid, table_specs, use_tracking=use_tracking
+            )
+            _record_uid_cleanup_scan(uid, query_results, deleted=False)
+        else:
+            delete_matches = list(table_matches or [])
+            if not delete_matches:
+                scan_summary = purge_uid_records(
+                    uid=uid,
+                    schemas=schemas,
+                    candidate_columns=candidate_columns,
+                    dry_run=True,
+                    use_tracking=use_tracking,
+                    allowed_tables=allowed_tables,
+                )
+                delete_matches = scan_summary["matches"]
 
-    for match in matches:
+            query_specs = []
+            for match in delete_matches:
+                qualified_table = (
+                    f"{_quote_identifier(match['schema'])}.{_quote_identifier(match['table'])}"
+                )
+                table_specs_lookup = {
+                    (spec["schema"], spec["table"]): spec for spec in table_specs
+                }
+                spec = table_specs_lookup.get((match["schema"], match["table"]))
+                if not spec or not match.get("scanned"):
+                    continue
+                query_specs.append(
+                    {
+                        "schema": match["schema"],
+                        "table": match["table"],
+                        "uid": uid,
+                        "columns": spec["columns"],
+                        "json_columns": spec["json_columns"],
+                        "incremental_column": match.get("incremental_column"),
+                        "last_incremental_value": match.get("last_incremental_value"),
+                        "skipped": False,
+                        "effective_where_clause": match.get("effective_where_clause"),
+                        "sql": _build_delete_sql(
+                            qualified_table,
+                            match.get("effective_where_clause", spec["where_clause"]),
+                            int(match["limit"]),
+                        ),
+                    }
+                )
+            query_results = _execute_scalar_queries_in_transaction(query_specs)
+            _record_uid_cleanup_scan(uid, query_results, deleted=True)
+
+        for result in query_results:
+            row_count = result["rows"]
+            if row_count <= 0:
+                continue
+            match_result = _build_match_result(result)
+            matches.append(match_result)
+            total_rows += row_count
+
+        action = "Found" if dry_run else "Deleted"
         logging.info(
-            "%s.%s via %s -> %s row(s)",
-            match["schema"],
-            match["table"],
-            ", ".join(match["match_sources"]),
-            match["rows"],
+            "%s %s matching row(s) for UID '%s' across %s table(s)",
+            action,
+            total_rows,
+            uid,
+            len(matches),
         )
 
-    return {
-        "uid": uid,
-        "dry_run": dry_run,
-        "scanned_tables": len(table_specs),
-        "affected_tables": len(matches),
-        "affected_rows": total_rows,
-        "matches": matches,
-    }
+        for match in matches:
+            logging.info(
+                "%s via %s -> %s row(s)",
+                match["table_name"],
+                ", ".join(match["match_sources"]),
+                match["rows"],
+            )
+
+        return {
+            "uid": uid,
+            "dry_run": dry_run,
+            "scanned_tables": len(table_specs),
+            "affected_tables": len(matches),
+            "affected_rows": total_rows,
+            "affected_table_names": [match["table_name"] for match in matches],
+            "tracking_enabled": use_tracking,
+            "matches": matches,
+        }
+    except Exception as exc:
+        logging.exception("UID cleanup failed for uid '%s'", uid)
+        _record_uid_cleanup_error(uid, str(exc))
+        return {
+            "uid": uid,
+            "dry_run": dry_run,
+            "scanned_tables": 0,
+            "affected_tables": 0,
+            "affected_rows": 0,
+            "affected_table_names": [],
+            "tracking_enabled": use_tracking,
+            "matches": [],
+        }
 
 
 def purge_known_test_uids(
@@ -354,6 +716,7 @@ def purge_known_test_uids(
             schemas=schemas,
             candidate_columns=candidate_columns,
             dry_run=True,
+            use_tracking=True,
         )
 
         if scan_result["affected_rows"] == 0:
@@ -390,6 +753,92 @@ def purge_known_test_uids(
             schemas=schemas,
             candidate_columns=candidate_columns,
             dry_run=False,
+            table_matches=scan_result["matches"],
+            use_tracking=True,
+        )
+        summary["uids_deleted"] += 1
+        summary["total_rows_deleted"] += delete_result["affected_rows"]
+        summary["results"].append(
+            {
+                "uid": uid,
+                "status": "deleted",
+                "rows": delete_result["affected_rows"],
+                "matches": delete_result["matches"],
+            }
+        )
+
+    return summary
+
+
+def purge_known_test_uids_source_only(
+    candidate_columns=None,
+    max_rows_per_uid: int = 100,
+):
+    """
+    Purge fixed known test UIDs only from source session tables.
+
+    This is intended as a lightweight preflight before the pipeline runs so
+    test data is removed from `public.sessions` and `public.clean_sessions`
+    before it spreads into downstream schemas and derived tables.
+    """
+    if max_rows_per_uid <= 0:
+        raise ValueError("max_rows_per_uid must be greater than zero")
+
+    summary = {
+        "uids_checked": len(KNOWN_TEST_UIDS),
+        "uids_deleted": 0,
+        "uids_skipped": 0,
+        "total_rows_deleted": 0,
+        "results": [],
+    }
+
+    for uid in KNOWN_TEST_UIDS:
+        scan_result = purge_uid_records(
+            uid=uid,
+            schemas=("public",),
+            candidate_columns=candidate_columns,
+            dry_run=True,
+            use_tracking=False,
+            allowed_tables=SOURCE_UID_CLEANUP_TABLES,
+        )
+
+        if scan_result["affected_rows"] == 0:
+            summary["results"].append(
+                {
+                    "uid": uid,
+                    "status": "not_found",
+                    "rows": 0,
+                    "matches": [],
+                }
+            )
+            continue
+
+        if scan_result["affected_rows"] > max_rows_per_uid:
+            logging.warning(
+                "Skipping source-only purge for UID '%s': dry run found %s row(s), above safeguard of %s",
+                uid,
+                scan_result["affected_rows"],
+                max_rows_per_uid,
+            )
+            summary["uids_skipped"] += 1
+            summary["results"].append(
+                {
+                    "uid": uid,
+                    "status": "skipped_max_rows",
+                    "rows": scan_result["affected_rows"],
+                    "matches": scan_result["matches"],
+                }
+            )
+            continue
+
+        delete_result = purge_uid_records(
+            uid=uid,
+            schemas=("public",),
+            candidate_columns=candidate_columns,
+            dry_run=False,
+            table_matches=scan_result["matches"],
+            use_tracking=False,
+            allowed_tables=SOURCE_UID_CLEANUP_TABLES,
         )
         summary["uids_deleted"] += 1
         summary["total_rows_deleted"] += delete_result["affected_rows"]

--- a/src/tests/test_run.py
+++ b/src/tests/test_run.py
@@ -10,13 +10,18 @@ To run the tests, run ``kedro test``.
 from pathlib import Path
 
 import pytest
+from kedro.config import ConfigLoader
 from kedro.framework.context import KedroContext
+from pluggy import PluginManager
 
 
 @pytest.fixture
 def project_context():
     return KedroContext(
-        package_name="data_pipeline", project_path=Path.cwd()
+        package_name="data_pipeline",
+        project_path=Path.cwd(),
+        config_loader=ConfigLoader(str(Path.cwd() / "conf")),
+        hook_manager=PluginManager("kedro"),
     )
 
 

--- a/src/tests/test_run.py
+++ b/src/tests/test_run.py
@@ -25,4 +25,4 @@ def project_context():
 # functionality
 class TestProjectContext:
     def test_package_name(self, project_context):
-        assert project_context.package_name == "data_pipeline"
+        assert project_context._package_name == "data_pipeline"


### PR DESCRIPTION
## [TICKET: NEOAPP-1289](https://neotree.atlassian.net/browse/NEOAPP-1289)

**Summary**
This PR adds a safe production cleanup path for removing test UIDs, including manual one-off cleanup and optional scheduled cleanup for approved known test UIDs.

The main use case is removing records for `AAAA-111111` without relying on ad hoc SQL or creating repeated dummy data in production during discharge printout testing.

**What Changed**
- Added `kedro purge-uid` for manual UID cleanup.
- Added `kedro purge-known-test-uids` for scheduled cleanup of fixed allowlisted test UIDs.
- Added transactional purge logic so delete operations succeed or roll back as a unit.
- Expanded matching to cover both standard UID columns and raw JSON-backed session payloads.
- Added a destructive-action safeguard for manual cleanup via `--confirm-uid`.
- Added a row-count safeguard for scheduled cleanup via `--max-rows-per-uid`.
- Updated `automation.py` to optionally install a second cron job for scheduled known test UID cleanup.
- Made cron job installation idempotent by replacing existing cron entries with the same comment instead of duplicating them.
- Updated `README.md` with manual cleanup, scheduled cleanup, and automation instructions.

**New Commands**
Manual dry run:
```powershell
kedro purge-uid --env=prod --uid AAAA-111111
```

Manual delete:
```powershell
kedro purge-uid --env=prod --uid AAAA-111111 --execute --confirm-uid AAAA-111111
```

Scheduled cleanup command:
```powershell
kedro purge-known-test-uids --env=prod
```

**Automation / Config**
Optional `database.ini` settings:
```ini
cron_interval = 6
known_test_uid_cleanup_interval = 12
known_test_uid_cleanup_max_rows = 100
```

If `known_test_uid_cleanup_interval > 0`, `automation.py` installs a second cron job for the known test UID cleanup alongside the normal pipeline cron job.

**Safety Notes**
- Manual deletes require explicit confirmation.
- Scheduled cleanup only operates on a fixed allowlist defined in code.
- Deletes run in a single transaction.
- Scheduled cleanup skips deletion if match volume exceeds the configured safeguard threshold.
