### PR TITLE
 Fix admissions/discharges join to retain unmatched discharge records

### DIFF
--- a/src/data_pipeline/pipelines/data_engineering/derive_data/create_joined_table_and_derived_columns.py
+++ b/src/data_pipeline/pipelines/data_engineering/derive_data/create_joined_table_and_derived_columns.py
@@ -394,17 +394,6 @@ def resolve_duplicate_matches(merged_df: pd.DataFrame, adm_unique_col: str = '_a
     return result
 
 
-def get_join_unique_key(df: pd.DataFrame) -> pd.Series:
-    """Return the best available unique key for joined rows."""
-    if 'unique_key' in df.columns and 'unique_key_discharge' in df.columns:
-        return df['unique_key'].combine_first(df['unique_key_discharge'])
-    if 'unique_key' in df.columns:
-        return df['unique_key']
-    if 'unique_key_discharge' in df.columns:
-        return df['unique_key_discharge']
-    return pd.Series([None] * len(df), index=df.index, dtype='object')
-
-
 def createJoinedDataSet(adm_df: pd.DataFrame, dis_df: pd.DataFrame) -> pd.DataFrame:
     """
     Create joined admissions-discharges dataset with intelligent duplicate resolution.
@@ -440,8 +429,9 @@ def createJoinedDataSet(adm_df: pd.DataFrame, dis_df: pd.DataFrame) -> pd.DataFr
         f"{len(adm_df)} admissions and {len(dis_df)} discharges"
     )
 
-    # Resolve duplicate matches only for rows attached to an admission.
-    # Right-only rows are unmatched discharges and should pass through unchanged.
+    # Pandas creates `_merge` because `indicator=True` is set above.
+    # We use it only as a temporary internal marker to identify `right_only`
+    # discharge rows before dropping the column again.
     right_only_rows = jn_adm_dis[jn_adm_dis['_merge'] == 'right_only'].copy()
     left_and_matched_rows = jn_adm_dis[jn_adm_dis['_merge'] != 'right_only'].copy()
 
@@ -450,20 +440,13 @@ def createJoinedDataSet(adm_df: pd.DataFrame, dis_df: pd.DataFrame) -> pd.DataFr
 
     jn_adm_dis = pd.concat([left_and_matched_rows, right_only_rows], ignore_index=True, sort=False)
 
-    # Clean up temporary merge bookkeeping.
+    # `_merge` is not part of the business schema; remove merge bookkeeping now.
     jn_adm_dis = jn_adm_dis.drop(columns=['_adm_idx', '_merge'], errors='ignore')
 
-    join_unique_key = get_join_unique_key(jn_adm_dis)
-    if not join_unique_key.empty:
-        # OPTIMIZATION: Use vectorized string operations instead of lambda map
-        join_unique_key_str = join_unique_key.astype(str)
-        jn_adm_dis['DEDUPLICATER'] = join_unique_key_str.str[:10]
-        # Replace empty strings or short values with None
-        jn_adm_dis.loc[join_unique_key_str.str.len() < 10, 'DEDUPLICATER'] = None
-
-        # Final deduplication on unique_key
+    dedup_subset = [col for col in ['uid', 'facility', 'unique_key', 'unique_key_discharge'] if col in jn_adm_dis.columns]
+    if dedup_subset:
         jn_adm_dis = jn_adm_dis.drop_duplicates(
-            subset=["uid", "facility", "DEDUPLICATER"],
+            subset=dedup_subset,
             keep='first'
         )
 

--- a/src/data_pipeline/pipelines/data_engineering/derive_data/create_joined_table_and_derived_columns.py
+++ b/src/data_pipeline/pipelines/data_engineering/derive_data/create_joined_table_and_derived_columns.py
@@ -394,6 +394,17 @@ def resolve_duplicate_matches(merged_df: pd.DataFrame, adm_unique_col: str = '_a
     return result
 
 
+def get_join_unique_key(df: pd.DataFrame) -> pd.Series:
+    """Return the best available unique key for joined rows."""
+    if 'unique_key' in df.columns and 'unique_key_discharge' in df.columns:
+        return df['unique_key'].combine_first(df['unique_key_discharge'])
+    if 'unique_key' in df.columns:
+        return df['unique_key']
+    if 'unique_key_discharge' in df.columns:
+        return df['unique_key_discharge']
+    return pd.Series([None] * len(df), index=df.index, dtype='object')
+
+
 def createJoinedDataSet(adm_df: pd.DataFrame, dis_df: pd.DataFrame) -> pd.DataFrame:
     """
     Create joined admissions-discharges dataset with intelligent duplicate resolution.
@@ -403,38 +414,52 @@ def createJoinedDataSet(adm_df: pd.DataFrame, dis_df: pd.DataFrame) -> pd.DataFr
     """
     logging.info("Creating joined dataset")
 
-    if adm_df.empty or dis_df.empty:
+    if adm_df.empty and dis_df.empty:
         logging.warning("Empty input dataframes - returning empty result")
         return pd.DataFrame()
 
-    # Add unique identifier to each admission row (will be preserved through merge)
     adm_df = adm_df.copy()
-    adm_df['_adm_idx'] = range(len(adm_df))
+    dis_df = dis_df.copy()
 
-    # Merge admissions and discharges on uid+facility
-    # This creates ALL possible admission-discharge combinations for each uid+facility pair
+    if not adm_df.empty:
+        # Preserve each admission identity so duplicate discharge matches can be resolved safely.
+        adm_df['_adm_idx'] = range(len(adm_df))
+
+    # Merge admissions and discharges on uid+facility.
+    # Use a full outer join so unmatched admissions and unmatched discharges are both retained.
     jn_adm_dis = adm_df.merge(
         dis_df,
-        how='left',
+        how='outer',
         on=['uid', 'facility'],
-        suffixes=('', '_discharge')
+        suffixes=('', '_discharge'),
+        indicator=True
     )
 
-    logging.info(f"Initial merge created {len(jn_adm_dis)} rows from {len(adm_df)} admissions")
+    logging.info(
+        f"Initial merge created {len(jn_adm_dis)} rows from "
+        f"{len(adm_df)} admissions and {len(dis_df)} discharges"
+    )
 
-    # Resolve duplicate matches using clinical measurement comparison
-    # For each admission, select the discharge with the best matching clinical measurements
-    jn_adm_dis = resolve_duplicate_matches(jn_adm_dis, adm_unique_col='_adm_idx')
+    # Resolve duplicate matches only for rows attached to an admission.
+    # Right-only rows are unmatched discharges and should pass through unchanged.
+    right_only_rows = jn_adm_dis[jn_adm_dis['_merge'] == 'right_only'].copy()
+    left_and_matched_rows = jn_adm_dis[jn_adm_dis['_merge'] != 'right_only'].copy()
 
-    # Clean up the temporary admission index column
-    jn_adm_dis = jn_adm_dis.drop(columns=['_adm_idx'], errors='ignore')
+    if not left_and_matched_rows.empty and '_adm_idx' in left_and_matched_rows.columns:
+        left_and_matched_rows = resolve_duplicate_matches(left_and_matched_rows, adm_unique_col='_adm_idx')
 
-    # Final deduplication based on unique_key (safety check)
-    if 'unique_key' in jn_adm_dis.columns:
+    jn_adm_dis = pd.concat([left_and_matched_rows, right_only_rows], ignore_index=True, sort=False)
+
+    # Clean up temporary merge bookkeeping.
+    jn_adm_dis = jn_adm_dis.drop(columns=['_adm_idx', '_merge'], errors='ignore')
+
+    join_unique_key = get_join_unique_key(jn_adm_dis)
+    if not join_unique_key.empty:
         # OPTIMIZATION: Use vectorized string operations instead of lambda map
-        jn_adm_dis['DEDUPLICATER'] = jn_adm_dis['unique_key'].astype(str).str[:10]
+        join_unique_key_str = join_unique_key.astype(str)
+        jn_adm_dis['DEDUPLICATER'] = join_unique_key_str.str[:10]
         # Replace empty strings or short values with None
-        jn_adm_dis.loc[jn_adm_dis['unique_key'].astype(str).str.len() < 10, 'DEDUPLICATER'] = None
+        jn_adm_dis.loc[join_unique_key_str.str.len() < 10, 'DEDUPLICATER'] = None
 
         # Final deduplication on unique_key
         jn_adm_dis = jn_adm_dis.drop_duplicates(

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -4,6 +4,7 @@ import json
 from psycopg2 import sql
 from data_pipeline.pipelines.data_engineering.queries.check_table_exists_sql import table_exists
 from  conf.common.config import config
+from conf.common.sql_functions import column_exists
 from datetime import datetime
 
 params = config()
@@ -444,31 +445,31 @@ WHERE NOT EXISTS (
 
 
 def read_dicharges_not_joined():
+        joined_unique_key = 'COALESCE(j.unique_key_discharge, j.unique_key)' if column_exists(
+            'derived', 'joined_admissions_discharges', 'unique_key_discharge'
+        ) else 'j.unique_key'
         return f'''SELECT * 
-FROM derived.discharges 
-WHERE uid IN (
-    SELECT uid 
-    FROM derived.admissions ad 
-    WHERE NOT EXISTS (
-        SELECT 1 
-        FROM derived.joined_admissions_discharges j 
-        WHERE ad.uid = j.uid 
-          AND ad.unique_key = j.unique_key
-    )
+FROM derived.discharges dis
+WHERE NOT EXISTS (
+    SELECT 1 
+    FROM derived.joined_admissions_discharges j 
+    WHERE dis.uid = j.uid
+      AND dis.facility = j.facility
+      AND dis.unique_key = {joined_unique_key}
 )'''
 
 def read_clean_dicharges_not_joined():
+        joined_unique_key = 'COALESCE(j.unique_key_discharge, j.unique_key)' if column_exists(
+            'derived', 'clean_joined_adm_discharges', 'unique_key_discharge'
+        ) else 'j.unique_key'
         return f'''SELECT * 
-FROM derived.clean_discharges 
-WHERE uid IN (
-    SELECT uid 
-    FROM derived.clean_admissions ad 
-    WHERE NOT EXISTS (
-        SELECT 1 
-        FROM derived.clean_joined_adm_discharges j 
-        WHERE ad.uid = j.uid 
-          AND ad.unique_key = j.unique_key
-    )
+FROM derived.clean_discharges dis
+WHERE NOT EXISTS (
+    SELECT 1 
+    FROM derived.clean_joined_adm_discharges j 
+    WHERE dis.uid = j.uid
+      AND dis.facility = j.facility
+      AND dis.unique_key = {joined_unique_key}
 )'''
 
 def admissions_without_discharges():

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -4,7 +4,6 @@ import json
 from psycopg2 import sql
 from data_pipeline.pipelines.data_engineering.queries.check_table_exists_sql import table_exists
 from  conf.common.config import config
-from conf.common.sql_functions import column_exists
 from datetime import datetime
 
 params = config()
@@ -445,9 +444,6 @@ WHERE NOT EXISTS (
 
 
 def read_dicharges_not_joined():
-        joined_unique_key = 'COALESCE(j.unique_key_discharge, j.unique_key)' if column_exists(
-            'derived', 'joined_admissions_discharges', 'unique_key_discharge'
-        ) else 'j.unique_key'
         return f'''SELECT * 
 FROM derived.discharges dis
 WHERE NOT EXISTS (
@@ -455,13 +451,10 @@ WHERE NOT EXISTS (
     FROM derived.joined_admissions_discharges j 
     WHERE dis.uid = j.uid
       AND dis.facility = j.facility
-      AND dis.unique_key = {joined_unique_key}
+      AND dis.unique_key = j.unique_key_discharge
 )'''
 
 def read_clean_dicharges_not_joined():
-        joined_unique_key = 'COALESCE(j.unique_key_discharge, j.unique_key)' if column_exists(
-            'derived', 'clean_joined_adm_discharges', 'unique_key_discharge'
-        ) else 'j.unique_key'
         return f'''SELECT * 
 FROM derived.clean_discharges dis
 WHERE NOT EXISTS (
@@ -469,7 +462,7 @@ WHERE NOT EXISTS (
     FROM derived.clean_joined_adm_discharges j 
     WHERE dis.uid = j.uid
       AND dis.facility = j.facility
-      AND dis.unique_key = {joined_unique_key}
+      AND dis.unique_key = j.unique_key_discharge
 )'''
 
 def admissions_without_discharges():


### PR DESCRIPTION
## TICKET : [NEOAPP-1297](https://neotree.atlassian.net/browse/NEOAPP-1297)

**Summary**

This PR updates the joined admissions/discharges build so the base joined table includes all relevant records from both sources, including discharge-only rows that were previously excluded.

The ticket reported that `joined_admissions_discharges` was behaving like an admission-led join: all admissions appeared, but unmatched discharges were missing. That behavior was confirmed in the pipeline code. The main join was implemented as a pandas left join from admissions to discharges, which structurally prevented discharge-only records from appearing in the joined output.


**Problem**

The existing join logic in [create_joined_table_and_derived_columns.py](C:/Users/HomePC/Neotree%20Projects/neotree-data-pipeline-kedro/src/data_pipeline/pipelines/data_engineering/derive_data/create_joined_table_and_derived_columns.py) merged admissions to discharges using `how='left'`.

That had two consequences:

1. Matched admissions/discharges were included.
2. Unmatched admissions were included.
3. Unmatched discharges were excluded by design.

There was also follow-up logic intended to pick up missing records incrementally, but the discharge-side query still depended on admissions, so it did not truly recover discharge-only rows.
