### PR TITLE
 Strip Malawi and Zimbabwe PII from raw session JSON before derived exports

### DIFF
--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -830,18 +830,33 @@ def insert_sessions_data():
 
     # f'''drop table if exists {table} cascade;;
     # CREATE INDEX IF NOT EXISTS idx_clean_sessions_cleaned ON {clean_sessions} (cleaned);;
-    return f'''CREATE TABLE IF NOT EXISTS public.clean_sessions (
+    return f'''ALTER TABLE {sessions}
+                ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE;;
+
+                CREATE INDEX IF NOT EXISTS idx_sessions_pii_cleaned
+                ON {sessions} (pii_cleaned);;
+
+                CREATE TABLE IF NOT EXISTS public.clean_sessions (
                 id INTEGER PRIMARY KEY,
                 uid TEXT,
                 ingested_at TIMESTAMP WITHOUT TIME ZONE,
                 data JSONB,
                 scriptid TEXT,
                 unique_key VARCHAR,
-                cleaned BOOLEAN
-            );;     
+                cleaned BOOLEAN,
+                pii_cleaned BOOLEAN DEFAULT FALSE
+            );;
+
+                ALTER TABLE {clean_sessions}
+                ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE;;
+
+                CREATE INDEX IF NOT EXISTS idx_clean_sessions_pii_cleaned
+                ON {clean_sessions} (pii_cleaned);;
         
         INSERT INTO {clean_sessions} 
-        SELECT *,false FROM {sessions} s
+        (id, uid, ingested_at, data, scriptid, unique_key, cleaned, pii_cleaned)
+        SELECT s.id, s.uid, s.ingested_at, s.data, s.scriptid, s.unique_key, false, COALESCE(s.pii_cleaned, false)
+        FROM {sessions} s
         WHERE NOT EXISTS (
         SELECT 1
         FROM {clean_sessions} cs
@@ -953,10 +968,21 @@ def clean_pii_patterns(schema: str, table: str):
     return rf"""
     {create_pii_redaction_functions()}
 
+    ALTER TABLE {fq}
+    ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE;;
+
+    CREATE INDEX IF NOT EXISTS idx_{schema}_{table}_pii_cleaned
+    ON {fq} (pii_cleaned);;
+
     UPDATE {fq}
     SET data = scratch.strip_pii_jsonb(data)
-    WHERE data IS NOT NULL
+    WHERE COALESCE(pii_cleaned, FALSE) = FALSE
+    AND data IS NOT NULL
     AND data::text ~ '([0-9]{{2}}[ -]?[0-9]{{6,7}}[ -]?[A-Za-z][ -]?[0-9]{{2}}|[A-Z][A-Z0-9]{{7}}|\+?265([ -]?[0-9]){{9}}|0([ -]?[0-9]){{9}}|[89]([ -]?[0-9]){{8}}|\+?263([ -]?[0-9]){{5,10}}|0([ -]?[0-9]){{5,10}}|7[1378]([ -]?[0-9]){{7}})';;
+
+    UPDATE {fq}
+    SET pii_cleaned = TRUE
+    WHERE COALESCE(pii_cleaned, FALSE) = FALSE;;
 
     """.strip()
 
@@ -995,7 +1021,8 @@ def clean_known_confidential_columns(schema: str, table: str):
     (data->'entries') - ARRAY[{arr}]::text[],
     true
     )
-    WHERE jsonb_typeof(data->'entries') = 'object'
+    WHERE COALESCE(pii_cleaned, FALSE) = FALSE
+    AND jsonb_typeof(data->'entries') = 'object'
     AND (data->'entries') ?| ARRAY[{arr}]::text[];;
 
     {clean_pii_patterns(schema, table)}

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -861,6 +861,106 @@ def regenerate_unique_key_query(id, unique_key):
               '''
 
 
+def create_pii_redaction_functions():
+    return r"""
+    CREATE SCHEMA IF NOT EXISTS scratch;;
+
+    CREATE OR REPLACE FUNCTION scratch.strip_pii_text(input_text text)
+    RETURNS text
+    LANGUAGE plpgsql
+    IMMUTABLE
+    AS $$
+    DECLARE
+        redacted text := input_text;
+        previous text;
+        pattern text;
+        redaction_pass integer := 0;
+        patterns text[] := ARRAY[
+            -- Zimbabwe national ID: DD-NNNNNN-L-DD or DD-NNNNNNN-L-DD.
+            '(^|[^[:alnum:]])[0-9]{2}[ -]?[0-9]{6,7}[ -]?[A-Za-z][ -]?[0-9]{2}(?=[^[:alnum:]]|$)',
+            -- Malawi national registration number: 8 uppercase alpha-numeric chars, starting with a letter.
+            -- Do not match inside hyphenated NeoTree UIDs such as ABDC-1234567 or A128-1234567.
+            '(^|[^[:alnum:]-])[A-Z][A-Z0-9]{7}(?=[^[:alnum:]-]|$)',
+            -- Malawi phone numbers. Strong prefix matches cover all 9-digit national numbers;
+            -- unprefixed matches stay mobile-focused to reduce false positives.
+            '(^|[^[:alnum:]])\+?265([ -]?[0-9]){9}(?=[^[:alnum:]]|$)',
+            '(^|[^[:alnum:]])0([ -]?[0-9]){9}(?=[^[:alnum:]]|$)',
+            '(^|[^[:alnum:]])[89]([ -]?[0-9]){8}(?=[^[:alnum:]]|$)',
+            -- Zimbabwe phone numbers. Strong prefix matches cover national numbers from 5 to 10 digits;
+            -- unprefixed matches stay mobile-focused to reduce false positives.
+            '(^|[^[:alnum:]])\+?263([ -]?[0-9]){5,10}(?=[^[:alnum:]]|$)',
+            '(^|[^[:alnum:]])0([ -]?[0-9]){5,10}(?=[^[:alnum:]]|$)',
+            '(^|[^[:alnum:]])7[1378]([ -]?[0-9]){7}(?=[^[:alnum:]]|$)'
+        ];
+    BEGIN
+        IF redacted IS NULL THEN
+            RETURN NULL;
+        END IF;
+
+        LOOP
+            previous := redacted;
+            redaction_pass := redaction_pass + 1;
+
+            FOREACH pattern IN ARRAY patterns LOOP
+                redacted := regexp_replace(redacted, pattern, '\1[PII_REMOVED]', 'g');
+            END LOOP;
+
+            EXIT WHEN redacted = previous OR redaction_pass >= 10;
+        END LOOP;
+
+        RETURN redacted;
+    END;
+    $$;;
+
+    CREATE OR REPLACE FUNCTION scratch.strip_pii_jsonb(input_json jsonb)
+    RETURNS jsonb
+    LANGUAGE sql
+    IMMUTABLE
+    AS $$
+        SELECT CASE jsonb_typeof(input_json)
+            WHEN 'object' THEN COALESCE(
+                (
+                    SELECT jsonb_object_agg(key, scratch.strip_pii_jsonb(value))
+                    FROM jsonb_each(input_json)
+                ),
+                '{}'::jsonb
+            )
+            WHEN 'array' THEN COALESCE(
+                (
+                    SELECT jsonb_agg(scratch.strip_pii_jsonb(value) ORDER BY ordinality)
+                    FROM jsonb_array_elements(input_json) WITH ORDINALITY AS arr(value, ordinality)
+                ),
+                '[]'::jsonb
+            )
+            WHEN 'string' THEN to_jsonb(scratch.strip_pii_text(input_json #>> '{}'))
+            WHEN 'number' THEN CASE
+                WHEN scratch.strip_pii_text(input_json #>> '{}') <> input_json #>> '{}'
+                THEN to_jsonb('[PII_REMOVED]'::text)
+                ELSE input_json
+            END
+            ELSE input_json
+        END
+    $$;;
+    """.strip()
+
+
+def clean_pii_patterns(schema: str, table: str):
+    def qident(s: str) -> str:
+        return '"' + s.replace('"', '""') + '"'
+
+    fq = f"{qident(schema)}.{qident(table)}"
+
+    return rf"""
+    {create_pii_redaction_functions()}
+
+    UPDATE {fq}
+    SET data = scratch.strip_pii_jsonb(data)
+    WHERE data IS NOT NULL
+    AND data::text ~ '([0-9]{{2}}[ -]?[0-9]{{6,7}}[ -]?[A-Za-z][ -]?[0-9]{{2}}|[A-Z][A-Z0-9]{{7}}|\+?265([ -]?[0-9]){{9}}|0([ -]?[0-9]){{9}}|[89]([ -]?[0-9]){{8}}|\+?263([ -]?[0-9]){{5,10}}|0([ -]?[0-9]){{5,10}}|7[1378]([ -]?[0-9]){{7}})';;
+
+    """.strip()
+
+
 def clean_known_confidential_columns(schema: str, table: str):
     def qident(s: str) -> str:
         return '"' + s.replace('"', '""') + '"'
@@ -897,6 +997,8 @@ def clean_known_confidential_columns(schema: str, table: str):
     )
     WHERE jsonb_typeof(data->'entries') = 'object'
     AND (data->'entries') ?| ARRAY[{arr}]::text[];;
+
+    {clean_pii_patterns(schema, table)}
     """.strip()
 
     return sql

--- a/src/tests/pipelines/data_engineering/test_pii_redaction_patterns.py
+++ b/src/tests/pipelines/data_engineering/test_pii_redaction_patterns.py
@@ -116,3 +116,15 @@ def test_sql_scrubber_handles_json_numbers():
 
     assert "WHEN 'number' THEN CASE" in source
     assert "THEN to_jsonb('[PII_REMOVED]'::text)" in source
+
+
+def test_sql_scrubber_is_incremental_with_pii_flag():
+    project_root = Path(__file__).parents[4]
+    assorted_queries = project_root / "src" / "data_pipeline" / "pipelines" / "data_engineering" / "queries" / "assorted_queries.py"
+
+    source = assorted_queries.read_text()
+
+    assert "ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE" in source
+    assert "WHERE COALESCE(pii_cleaned, FALSE) = FALSE" in source
+    assert "SET pii_cleaned = TRUE" in source
+    assert "COALESCE(s.pii_cleaned, false)" in source

--- a/src/tests/pipelines/data_engineering/test_pii_redaction_patterns.py
+++ b/src/tests/pipelines/data_engineering/test_pii_redaction_patterns.py
@@ -1,0 +1,118 @@
+import re
+from pathlib import Path
+
+
+PATTERNS = [
+    r"(^|[^A-Za-z0-9])[0-9]{2}[ -]?[0-9]{6,7}[ -]?[A-Za-z][ -]?[0-9]{2}(?=[^A-Za-z0-9]|$)",
+    r"(^|[^A-Za-z0-9-])[A-Z][A-Z0-9]{7}(?=[^A-Za-z0-9-]|$)",
+    r"(^|[^A-Za-z0-9])\+?265([ -]?[0-9]){9}(?=[^A-Za-z0-9]|$)",
+    r"(^|[^A-Za-z0-9])0([ -]?[0-9]){9}(?=[^A-Za-z0-9]|$)",
+    r"(^|[^A-Za-z0-9])[89]([ -]?[0-9]){8}(?=[^A-Za-z0-9]|$)",
+    r"(^|[^A-Za-z0-9])\+?263([ -]?[0-9]){5,10}(?=[^A-Za-z0-9]|$)",
+    r"(^|[^A-Za-z0-9])0([ -]?[0-9]){5,10}(?=[^A-Za-z0-9]|$)",
+    r"(^|[^A-Za-z0-9])7[1378]([ -]?[0-9]){7}(?=[^A-Za-z0-9]|$)",
+]
+
+
+def redact(value: str) -> str:
+    redacted = value
+    for _ in range(10):
+        previous = redacted
+        for pattern in PATTERNS:
+            redacted = re.sub(pattern, r"\1[PII_REMOVED]", redacted)
+        if redacted == previous:
+            break
+    return redacted
+
+
+def test_redacts_country_specific_phone_number_formats():
+    examples = [
+        "+265 9 1234 5678",
+        "+265991234567",
+        "265 991 234 567",
+        "265-991-234-567",
+        "0991 23 45 67",
+        "0991234567",
+        "991234567",
+        "891 234 567",
+        "+263 242 123456",
+        "+263242123456",
+        "+263 77 123 4567",
+        "263-77-123-4567",
+        "0771234567",
+        "077 123 4567",
+        "771234567",
+    ]
+
+    for example in examples:
+        assert redact(f"phone {example} done") == "phone [PII_REMOVED] done"
+
+
+def test_redacts_national_id_formats():
+    examples = [
+        "63-123456-A-12",
+        "63123456A12",
+        "63 1234567 A 12",
+        "631234567A12",
+        "631234567a12",
+        "63-1234567-A-12",
+        "A1B2C3D4",
+        "Z9999999",
+    ]
+
+    for example in examples:
+        assert redact(f"id {example} done") == "id [PII_REMOVED] done"
+
+
+def test_preserves_hyphenated_neotree_uids():
+    examples = [
+        "ABDC-1234567",
+        "A128-1234567",
+        "1234-1234567",
+        "0EE2-6244",
+    ]
+
+    for example in examples:
+        assert redact(example) == example
+
+
+def test_redacts_multiple_pii_values_in_one_text_value():
+    value = "mother 0991234567 father +263 77 123 4567 nrn A1B2C3D4"
+
+    assert redact(value) == "mother [PII_REMOVED] father [PII_REMOVED] nrn [PII_REMOVED]"
+
+
+def test_preserves_common_non_pii_codes_and_dates():
+    examples = [
+        "ABCD123",
+        "A1B2C3D4-EXTRA",
+        "2024-01-31",
+        "facility SMCH ward KMC",
+        "weight 1234 grams",
+        "temperature 36.5",
+    ]
+
+    for example in examples:
+        assert redact(example) == example
+
+
+def test_numeric_phone_like_values_are_redactable_by_patterns():
+    examples = [
+        "265991234567",
+        "991234567",
+        "263771234567",
+        "0771234567",
+    ]
+
+    for example in examples:
+        assert redact(example) == "[PII_REMOVED]"
+
+
+def test_sql_scrubber_handles_json_numbers():
+    project_root = Path(__file__).parents[4]
+    assorted_queries = project_root / "src" / "data_pipeline" / "pipelines" / "data_engineering" / "queries" / "assorted_queries.py"
+
+    source = assorted_queries.read_text()
+
+    assert "WHEN 'number' THEN CASE" in source
+    assert "THEN to_jsonb('[PII_REMOVED]'::text)" in source


### PR DESCRIPTION

**Summary**

This PR adds regex-based PII redaction to the data engineering pipeline so sensitive Malawi/Zimbabwe phone numbers and national ID values are removed from raw JSON payloads before downstream derived tables and exports are produced.

The cleanup is applied during the existing deduplication stage, alongside the current known confidential field removal.

**Pipeline Impact**

The cleanup runs before derived tables are created:

```python
clean_known_confidential_columns("public", "sessions")
clean_known_confidential_columns("public", "clean_sessions")
```

This means PII is removed from `public.sessions` and `public.clean_sessions` before deduplication and downstream derived/export processing.

**Testing**

```powershell
python -c "import sys; sys.path.insert(0, r'src/tests/pipelines/data_engineering'); import test_pii_redaction_patterns as t; t.test_redacts_country_specific_phone_number_formats(); t.test_redacts_national_id_formats(); t.test_preserves_hyphenated_neotree_uids(); t.test_redacts_multiple_pii_values_in_one_text_value(); t.test_preserves_common_non_pii_codes_and_dates(); t.test_numeric_phone_like_values_are_redactable_by_patterns(); t.test_sql_scrubber_handles_json_numbers(); print('expanded pii pattern tests passed')"

```

**Notes / Tradeoffs**

This implementation is privacy-favoring. Some false positives are possible, especially for standalone 8-character uppercase alphanumeric tokens that match the Malawi national ID format. The regexes were tightened to avoid known NeoTree UID formats and common lowercase text false positives.