### PR TITLE
Fix pii_cleaned column creation order in step 1 cleanup

### DIFF
--- a/src/data_pipeline/pipelines/data_engineering/nodes_grouped/step_1_nodes/deduplicate_data.py
+++ b/src/data_pipeline/pipelines/data_engineering/nodes_grouped/step_1_nodes/deduplicate_data.py
@@ -17,9 +17,9 @@ def deduplicate_data(data_import_output):
             #Clean Up Confidential Columns From Source
             logging.info("******CLEANING KNOWN CONFIDENTIALITY COLUMNS*********")
             inject_sql(clean_known_confidential_columns("public","sessions"),"confidential-sessions")
-            inject_sql(clean_known_confidential_columns("public","clean_sessions"),"confidential-clean-sessions")
             logging.info("******START DATA CLEANING*********")
             inject_sql(insert_sessions_data(),"Sessions Data")
+            inject_sql(clean_known_confidential_columns("public","clean_sessions"),"confidential-clean-sessions")
             logging.info("******DONE INSERTING INTO CLEAN SESSIONS*********") 
             regenerate_unique_key()
             ###DEDUPLICATE DYNAMICALLY

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -968,12 +968,6 @@ def clean_pii_patterns(schema: str, table: str):
     return rf"""
     {create_pii_redaction_functions()}
 
-    ALTER TABLE {fq}
-    ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE;;
-
-    CREATE INDEX IF NOT EXISTS idx_{schema}_{table}_pii_cleaned
-    ON {fq} (pii_cleaned);;
-
     UPDATE {fq}
     SET data = scratch.strip_pii_jsonb(data)
     WHERE COALESCE(pii_cleaned, FALSE) = FALSE
@@ -1014,6 +1008,12 @@ def clean_known_confidential_columns(schema: str, table: str):
     arr = ", ".join("'" + k.replace("'", "''") + "'" for k in keys)
 
     sql = f"""
+    ALTER TABLE {fq}
+    ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE;;
+
+    CREATE INDEX IF NOT EXISTS idx_{schema}_{table}_pii_cleaned
+    ON {fq} (pii_cleaned);;
+
     UPDATE {fq}
     SET data = jsonb_set(
     data,


### PR DESCRIPTION
**Summary**

This PR fixes a pipeline failure caused by referencing the new `pii_cleaned` column before it existed.

The failure happened during step 1 cleanup when `clean_known_confidential_columns(...)` tried to run an `UPDATE ... WHERE COALESCE(pii_cleaned, FALSE) = FALSE` before the column had been created on the target table.

**Problem**

The cleanup flow was executing in this order:
1. run confidential field cleanup
2. reference `pii_cleaned` in the `WHERE` clause
3. only later create `pii_cleaned`

As a result, PostgreSQL raised:

```text
column "pii_cleaned" does not exist
```

**Fix**

The fix moves creation of the tracking column and its index to the start of `clean_known_confidential_columns(...)`, before any cleanup SQL references `pii_cleaned`.

The new order is:
1. `ALTER TABLE ... ADD COLUMN IF NOT EXISTS pii_cleaned BOOLEAN DEFAULT FALSE`
2. `CREATE INDEX IF NOT EXISTS ...`
3. remove known confidential entry fields
4. run regex-based PII cleanup
5. mark processed rows as `pii_cleaned = true`