### PR TITLE
Harden PII cleanup and prevent insert failures

### DIFF
--- a/conf/common/sql_functions.py
+++ b/conf/common/sql_functions.py
@@ -1369,6 +1369,20 @@ def generate_postgres_insert(df, schema, table_name):
     except Exception as e:
         logging.warning(f"Could not verify/update table structure: {e}")
 
+    # Fetch column types before building values so inserts can respect the
+    # actual destination types instead of inferring from the raw values.
+    column_types = {}
+    try:
+        table_cols_with_types = get_table_columns(table_name, schema)
+        column_types = {col[0]: col[1] for col in table_cols_with_types} if table_cols_with_types else {}
+    except Exception as e:
+        logging.warning(f"Could not fetch column types for insert preparation: {e}")
+
+    bool_map = {
+        'y': True, 'yes': True, 'true': True, '1': True, True: True,
+        'n': False, 'no': False, 'false': False, '0': False, False: False
+    }
+
     # Build values rows - MUST iterate in the same order as valid_columns
     values_rows = []
     for idx in df.index:
@@ -1376,6 +1390,7 @@ def generate_postgres_insert(df, schema, table_name):
         # Iterate through columns in the EXACT same order as valid_columns
         for col in valid_columns:
             val = df.at[idx, col]
+            col_type = column_types.get(col, 'unknown').lower()
 
             # NULL handling (safe for arrays/lists)
             if not isinstance(val, (list, dict)) and (
@@ -1390,15 +1405,39 @@ def generate_postgres_insert(df, schema, table_name):
             elif isinstance(val, (list, dict)):
                 json_val = json.dumps(val)
                 row_values.append(f"'{escape_special_characters(json_val)}'")
-            elif isinstance(val, (pd.Timestamp, pd.Timedelta)):
-                # Handle timezone-aware timestamps by converting to naive
-                if isinstance(val, pd.Timestamp) and val.tz is not None:
-                    val = val.tz_localize(None)  # Remove timezone info
-                converted = f"'{clean_datetime_string(str(val))}'"
-                row_values.append("NULL" if converted.strip("'") in {'NaT', 'None', 'nan', '', '<NA>'} else converted)
-            elif is_date_prefix(str(val)) and col != 'unique_key':
-                converted_date_like = f"'{clean_datetime_string(str(val))}'"
-                row_values.append("NULL" if converted_date_like.strip("'") in {'NaT', 'None', 'nan', '', '<NA>'} else converted_date_like)
+            elif 'bool' in col_type:
+                val_str = str(val).strip().lower()
+                mapped = bool_map.get(val_str, bool_map.get(val, None))
+                row_values.append("NULL" if mapped is None else ('TRUE' if mapped else 'FALSE'))
+            elif any(t in col_type for t in ['int', 'numeric', 'double', 'real', 'float', 'decimal']):
+                try:
+                    num_val = pd.to_numeric(val, errors='coerce')
+                    if pd.isna(num_val):
+                        row_values.append("NULL")
+                    else:
+                        row_values.append(str(float(num_val)))
+                except Exception:
+                    row_values.append("NULL")
+            elif 'timestamp' in col_type or 'date' in col_type:
+                if isinstance(val, (pd.Timestamp, pd.Timedelta)):
+                    # Handle timezone-aware timestamps by converting to naive
+                    if isinstance(val, pd.Timestamp) and val.tz is not None:
+                        val = val.tz_localize(None)  # Remove timezone info
+                    converted = f"'{clean_datetime_string(str(val))}'"
+                    row_values.append("NULL" if converted.strip("'") in {'NaT', 'None', 'nan', '', '<NA>'} else converted)
+                elif is_date_prefix(str(val)) and col != 'unique_key':
+                    converted_date_like = f"'{clean_datetime_string(str(val))}'"
+                    row_values.append("NULL" if converted_date_like.strip("'") in {'NaT', 'None', 'nan', '', '<NA>'} else converted_date_like)
+                else:
+                    logging.warning(
+                        "Nulling invalid date-like value for %s.%s.%s at row %s. Value=%r",
+                        schema,
+                        table_name,
+                        col,
+                        idx,
+                        val,
+                    )
+                    row_values.append("NULL")
             elif isinstance(val, str):
                 row_values.append(f"'{escape_special_characters(val)}'")
             else:
@@ -1411,14 +1450,6 @@ def generate_postgres_insert(df, schema, table_name):
         return
 
     # OPTIMIZATION 3: Use batch inserts for very large datasets
-    # Get column types to detect potential type mismatches
-    column_types = {}
-    try:
-        table_cols_with_types = get_table_columns(table_name, schema)
-        column_types = {col[0]: col[1] for col in table_cols_with_types} if table_cols_with_types else {}
-    except Exception as e:
-        logging.warning(f"Could not fetch column types for validation: {e}")
-
     batch_size = 1000
     for i in range(0, len(values_rows), batch_size):
         batch = values_rows[i:i + batch_size]

--- a/src/data_pipeline/pipelines/data_engineering/data_tyding/tidy_admissions_discharges_and_create_mcl_tables.py
+++ b/src/data_pipeline/pipelines/data_engineering/data_tyding/tidy_admissions_discharges_and_create_mcl_tables.py
@@ -269,6 +269,32 @@ def add_new_columns_if_needed(df: pd.DataFrame, table_name: str, schema: str = '
                 create_new_columns(table_name, schema, column_pairs)
 
 
+def coerce_numeric_columns(df: pd.DataFrame, columns: List[str], table_name: str) -> pd.DataFrame:
+    """Force known numeric columns to numeric/null and log dropped invalid values."""
+    for col in columns:
+        if col not in df.columns:
+            continue
+
+        original = df[col]
+        converted = pd.to_numeric(original, errors='coerce')
+
+        invalid_mask = original.notna() & converted.isna()
+        invalid_count = int(invalid_mask.sum())
+        if invalid_count > 0:
+            samples = original[invalid_mask].astype(str).head(3).tolist()
+            logging.warning(
+                "Coerced %s invalid value(s) to NULL in %s.%s. Samples: %s",
+                invalid_count,
+                table_name,
+                col,
+                samples,
+            )
+
+        df[col] = converted
+
+    return df
+
+
 def finalize_dataframe(df: pd.DataFrame, table_name: str, schema: str = 'derived') -> pd.DataFrame:
     """Apply final transformations to dataframe before saving."""
     df = convert_false_numbers_to_text(df, schema, table_name)
@@ -445,6 +471,18 @@ def process_admissions_dataframe(adm_raw: pd.DataFrame, adm_new_entries: Any, ad
                         'BalScoreWks', 'BirthWeight', 'DurationLab', 'BloodSugarmg', 'AntenatalCare',
                         'BloodSugarmmol', 'AdmissionWeight']
         adm_df = format_column_as_numeric(adm_df, numeric_fields)
+        adm_df = coerce_numeric_columns(
+            adm_df,
+            [
+                'MatAgeYrs',
+                'MatAgeYrs.value',
+                'matageyrs',
+                'MatAge',
+                'MatAge.value',
+                'matage',
+            ],
+            'admissions',
+        )
         # Convert Series to DataFrame if needed
         if isinstance(adm_df, pd.Series):
             adm_df = adm_df.to_frame().T

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -9,6 +9,7 @@ from datetime import datetime
 params = config()
 env = params['env']
 PII_CLEANED_VERSION = 2
+PII_CLEANUP_BATCH_SIZE = 5000
 
 # TO BE USED AS IT IS AS IT CONTAINS SPECIAL REQUIREMENTS
 
@@ -1106,7 +1107,7 @@ def create_pii_redaction_functions():
                 CASE
                     WHEN input_json ? 'entries' THEN jsonb_set(
                         input_json,
-                        '{entries}',
+                        '{{entries}}',
                         scratch.strip_pii_entries_jsonb(input_json->'entries'),
                         true
                     )
@@ -1143,11 +1144,11 @@ def clean_pii_patterns(schema: str, table: str):
     WHERE table_schema = '{schema}'
     AND table_name = '{table}';;
 
-    DROP TABLE IF EXISTS scratch.pii_redaction_candidates;;
+    DROP TABLE IF EXISTS pii_redaction_candidates;;
 
-    CREATE TABLE scratch.pii_redaction_candidates AS
+    CREATE TEMP TABLE pii_redaction_candidates ON COMMIT DROP AS
     SELECT
-        id,
+        t.id,
         data AS original_data,
         scratch.strip_pii_jsonb(data) AS redacted_data,
         (
@@ -1155,10 +1156,9 @@ def clean_pii_patterns(schema: str, table: str):
             OR scratch.strip_pii_jsonb(data)::text LIKE '%T[PII_REMOVED]%'
             OR scratch.strip_pii_jsonb(data)::text LIKE '%-[PII_REMOVED]-%'
         ) AS suspicious_output
-    FROM {fq}
-    WHERE COALESCE(pii_cleaned_version, CASE WHEN COALESCE(pii_cleaned, FALSE) THEN 1 ELSE 0 END, 0) < {PII_CLEANED_VERSION}
-    AND data IS NOT NULL
-    AND data ? 'entries';;
+    FROM {fq} t
+    JOIN pii_cleanup_targets target_rows
+      ON t.id = target_rows.id;;
 
     INSERT INTO scratch.pii_redaction_skips (
         table_schema,
@@ -1185,7 +1185,7 @@ def clean_pii_patterns(schema: str, table: str):
         END,
         left(candidates.redacted_data::text, 300)
     FROM {fq} t
-    JOIN scratch.pii_redaction_candidates candidates
+    JOIN pii_redaction_candidates candidates
       ON t.id = candidates.id
     WHERE candidates.suspicious_output = TRUE;;
 
@@ -1193,7 +1193,7 @@ def clean_pii_patterns(schema: str, table: str):
     SET data = candidates.redacted_data,
     pii_cleaned = TRUE,
     pii_cleaned_version = {PII_CLEANED_VERSION}
-    FROM scratch.pii_redaction_candidates candidates
+    FROM pii_redaction_candidates candidates
     WHERE {fq}.id = candidates.id
     AND candidates.suspicious_output = FALSE;;
 
@@ -1201,25 +1201,12 @@ def clean_pii_patterns(schema: str, table: str):
     SET data = candidates.original_data,
     pii_cleaned = FALSE,
     pii_cleaned_version = 0
-    FROM scratch.pii_redaction_candidates candidates
+    FROM pii_redaction_candidates candidates
     WHERE {fq}.id = candidates.id
     AND candidates.suspicious_output = TRUE;;
 
-    UPDATE {fq}
-    SET pii_cleaned = TRUE,
-    pii_cleaned_version = {PII_CLEANED_VERSION}
-    WHERE COALESCE(pii_cleaned_version, CASE WHEN COALESCE(pii_cleaned, FALSE) THEN 1 ELSE 0 END, 0) < {PII_CLEANED_VERSION};;
-
-    UPDATE {fq}
-    SET pii_cleaned = FALSE,
-    pii_cleaned_version = 0
-    WHERE id IN (
-        SELECT id
-        FROM scratch.pii_redaction_candidates
-        WHERE suspicious_output = TRUE
-    );;
-
-    DROP TABLE IF EXISTS scratch.pii_redaction_candidates;;
+    DROP TABLE IF EXISTS pii_redaction_candidates;;
+    DROP TABLE IF EXISTS pii_cleanup_targets;;
 
     """.strip()
 
@@ -1299,6 +1286,17 @@ def clean_known_confidential_columns(schema: str, table: str):
     CREATE INDEX IF NOT EXISTS idx_{schema}_{table}_pii_cleaned_version
     ON {fq} (pii_cleaned_version);;
 
+    DROP TABLE IF EXISTS pii_cleanup_targets;;
+
+    CREATE TEMP TABLE pii_cleanup_targets ON COMMIT DROP AS
+    SELECT id
+    FROM {fq}
+    WHERE COALESCE(pii_cleaned_version, CASE WHEN COALESCE(pii_cleaned, FALSE) THEN 1 ELSE 0 END, 0) < {PII_CLEANED_VERSION}
+    AND data IS NOT NULL
+    AND data ? 'entries'
+    ORDER BY ingested_at DESC NULLS LAST, id DESC
+    LIMIT {PII_CLEANUP_BATCH_SIZE};;
+
     UPDATE {fq}
     SET data = jsonb_set(
     data,
@@ -1306,7 +1304,7 @@ def clean_known_confidential_columns(schema: str, table: str):
     (data->'entries') - ARRAY[{arr}]::text[],
     true
     )
-    WHERE COALESCE(pii_cleaned_version, CASE WHEN COALESCE(pii_cleaned, FALSE) THEN 1 ELSE 0 END, 0) < {PII_CLEANED_VERSION}
+    WHERE id IN (SELECT id FROM pii_cleanup_targets)
     AND jsonb_typeof(data->'entries') = 'object'
     AND (data->'entries') ?| ARRAY[{arr}]::text[];;
 


### PR DESCRIPTION
This PR makes the data pipeline safer in two areas:

1. PII cleanup is now bounded and safer operationally
2. `clean_admissions` inserts no longer fail when bad values land in typed numeric/date columns

**What Changed**

- Limited PII cleanup to a maximum of `5,000` records per run
- PII cleanup now processes the newest unprocessed rows first
- PII cleanup batch state now uses temp tables to avoid cross-run collisions
- Suspicious redaction results are still skipped/restored instead of being persisted

- Hardened `generate_postgres_insert()` to respect destination column types
  - numeric columns now coerce invalid values to `NULL`
  - boolean columns map cleanly to `TRUE/FALSE`
  - date/timestamp conversion only applies to actual date/timestamp target columns
  - invalid date values that are nulled are logged

- Added upstream numeric coercion in the admissions tidy path for maternal-age fields
  - `MatAgeYrs`
  - `MatAgeYrs.value`
  - `matageyrs`
  - `MatAge`
  - `MatAge.value`
  - `matage`
  - invalid values are nulled and logged before insert