### PR TITLE
Fix PII cleanup temp-table lifetime bug and run cleanup/redaction in one execution path

### DIFF
--- a/src/data_pipeline/pipelines/data_engineering/nodes_grouped/step_1_nodes/deduplicate_data.py
+++ b/src/data_pipeline/pipelines/data_engineering/nodes_grouped/step_1_nodes/deduplicate_data.py
@@ -5,7 +5,7 @@ from conf.common.sql_functions import inject_sql, inject_sql_with_return
 from conf.base.catalog import cron_log_file,generic_dedup_queries,cron_time,env
 from data_pipeline.pipelines.data_engineering.queries.assorted_queries import (
     insert_sessions_data,
-    clean_known_confidential_columns,
+    clean_known_confidential_and_pii_columns,
     pii_skipped_redaction_summary_query,
 )
 from conf.common.config import config
@@ -42,8 +42,11 @@ def deduplicate_data(data_import_output):
         if data_import_output is not None:
             logging.info("******START DATA CLEANING*********")
             inject_sql(insert_sessions_data(),"Sessions Data")
-            logging.info("******CLEANING KNOWN CONFIDENTIALITY COLUMNS ON CLEAN SESSIONS*********")
-            inject_sql(clean_known_confidential_columns("public","clean_sessions"),"confidential-clean-sessions")
+            logging.info("******CLEANING AND REDACTING PII ON CLEAN SESSIONS*********")
+            inject_sql(
+                clean_known_confidential_and_pii_columns("public","clean_sessions"),
+                "confidential-clean-sessions"
+            )
             log_pii_skip_summary("public", "clean_sessions")
             logging.info("******DONE INSERTING INTO CLEAN SESSIONS*********") 
             regenerate_unique_key()

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -1363,3 +1363,11 @@ def clean_known_confidential_columns(schema: str, table: str):
     """.strip()
 
     return sql
+
+
+def clean_known_confidential_and_pii_columns(schema: str, table: str):
+    return f"""
+    {clean_known_confidential_columns(schema, table)}
+    ;;
+    {clean_pii_patterns(schema, table)}
+    """.strip()

--- a/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
+++ b/src/data_pipeline/pipelines/data_engineering/queries/assorted_queries.py
@@ -1199,7 +1199,7 @@ def clean_pii_patterns(schema: str, table: str):
 
     DROP TABLE IF EXISTS pii_redaction_candidates;;
 
-    CREATE TEMP TABLE pii_redaction_candidates ON COMMIT DROP AS
+    CREATE TEMP TABLE pii_redaction_candidates AS
     SELECT
         t.id,
         data AS original_data,
@@ -1341,7 +1341,7 @@ def clean_known_confidential_columns(schema: str, table: str):
 
     DROP TABLE IF EXISTS pii_cleanup_targets;;
 
-    CREATE TEMP TABLE pii_cleanup_targets ON COMMIT DROP AS
+    CREATE TEMP TABLE pii_cleanup_targets AS
     SELECT id
     FROM {fq}
     WHERE COALESCE(pii_cleaned_version, CASE WHEN COALESCE(pii_cleaned, FALSE) THEN 1 ELSE 0 END, 0) < {PII_CLEANED_VERSION}


### PR DESCRIPTION
**Summary**

This PR fixes a bug in the `clean_sessions` PII cleanup flow where temp tables were being dropped before later SQL statements could use them.

The issue was caused by a mismatch between:
- temp tables created with `ON COMMIT DROP`
- and `inject_sql()`, which commits after every `;;` SQL command

As a result, the batch target table `pii_cleanup_targets` was dropped immediately after creation, and later cleanup statements failed with: